### PR TITLE
support ESP8266 and increase sleep time in get_channel_data()

### DIFF
--- a/components/tsl2561/tsl2561.c
+++ b/components/tsl2561/tsl2561.c
@@ -43,7 +43,7 @@ static const char *TAG = "TSL2561";
 // Integration times in useconds
 #define TSL2561_INTEGRATION_TIME_13MS  20
 #define TSL2561_INTEGRATION_TIME_101MS 110
-#define TSL2561_INTEGRATION_TIME_402MS 410 // Default
+#define TSL2561_INTEGRATION_TIME_402MS 420 // Default
 
 // Calculation constants
 #define LUX_SCALE     14
@@ -138,6 +138,8 @@ static inline esp_err_t disable(tsl2561_t *dev)
 
 static inline esp_err_t get_channel_data(tsl2561_t *dev, uint16_t *channel0, uint16_t *channel1)
 {
+    int sleep_ms;
+
     I2C_DEV_TAKE_MUTEX(&dev->i2c_dev);
     I2C_DEV_CHECK(&dev->i2c_dev, enable(dev));
 
@@ -146,21 +148,23 @@ static inline esp_err_t get_channel_data(tsl2561_t *dev, uint16_t *channel0, uin
     switch (dev->integration_time)
     {
         case TSL2561_INTEGRATION_13MS:
-            SLEEP_MS(TSL2561_INTEGRATION_TIME_13MS);
+            sleep_ms = TSL2561_INTEGRATION_TIME_13MS;
             break;
         case TSL2561_INTEGRATION_101MS:
-            SLEEP_MS(TSL2561_INTEGRATION_TIME_101MS);
+            sleep_ms = TSL2561_INTEGRATION_TIME_101MS;
             break;
         default:
-            SLEEP_MS(TSL2561_INTEGRATION_TIME_402MS);
+            sleep_ms = TSL2561_INTEGRATION_TIME_402MS;
             break;
     }
+    SLEEP_MS(sleep_ms);
 
     I2C_DEV_CHECK(&dev->i2c_dev, read_register_16(dev, TSL2561_REG_CHANNEL_0_LOW, channel0));
     I2C_DEV_CHECK(&dev->i2c_dev, read_register_16(dev, TSL2561_REG_CHANNEL_1_LOW, channel1));
 
     I2C_DEV_CHECK(&dev->i2c_dev, disable(dev));
     I2C_DEV_GIVE_MUTEX(&dev->i2c_dev);
+    ESP_LOGD(TAG, "integration time: %d ms channel0: 0x%x channel1: 0x%x", sleep_ms, *channel0, *channel1);
 
     return ESP_OK;
 }
@@ -173,7 +177,8 @@ esp_err_t tsl2561_init_desc(tsl2561_t *dev, uint8_t addr, i2c_port_t port, gpio_
 
     if (addr != TSL2561_I2C_ADDR_GND && addr != TSL2561_I2C_ADDR_FLOAT && addr != TSL2561_I2C_ADDR_VCC)
     {
-        ESP_LOGE(TAG, "Invalid I2C address");
+        ESP_LOGE(TAG, "Invalid I2C address `0x%x`: must be one of 0x%x, 0x%x, 0x%x",
+                addr, TSL2561_I2C_ADDR_GND, TSL2561_I2C_ADDR_FLOAT, TSL2561_I2C_ADDR_VCC);
         return ESP_ERR_INVALID_ARG;
     }
 

--- a/examples/tsl2561/README.md
+++ b/examples/tsl2561/README.md
@@ -1,0 +1,45 @@
+## What the example does
+
+The example continually prints illuminance in lux to serial console. An
+example:
+
+```
+I (43) boot: ESP-IDF v3.2-18-gf1b9e15b-dirty 2nd stage bootloader
+I (43) boot: compile time 15:41:21
+I (44) qio_mode: Enabling default flash chip QIO
+I (52) boot: SPI Speed      : 40MHz
+I (58) boot: SPI Mode       : QIO
+I (64) boot: SPI Flash Size : 2MB
+I (71) boot: Partition Table:
+I (76) boot: ## Label            Usage          Type ST Offset   Length
+I (87) boot:  0 nvs              WiFi data        01 02 00009000 00006000
+I (99) boot:  1 phy_init         RF data          01 01 0000f000 00001000
+I (110) boot:  2 factory          factory app      00 00 00010000 000f0000
+I (122) boot: End of partition table
+I (128) esp_image: segment 0: paddr=0x00010010 vaddr=0x40210010 size=0x338ac (211116) map
+I (203) esp_image: segment 1: paddr=0x000438c4 vaddr=0x3ffe8000 size=0x0051c (  1308) load
+I (204) esp_image: segment 2: paddr=0x00043de8 vaddr=0x3ffe851c size=0x0019c (   412) load
+I (215) esp_image: segment 3: paddr=0x00043f8c vaddr=0x40100000 size=0x05adc ( 23260) load
+I (234) boot: Loaded app from partition at offset 0x10000
+I (281) system_api: Base MAC address is not set, read default base MAC address from BLK0 of EFUSE
+I (291) system_api: Base MAC address is not set, read default base MAC address from BLK0 of EFUSE
+I (481) phy_init: phy ver: 1055_12
+I (491) reset_reason: RTC reset 2 wakeup 0 store 0, reason is 2
+I (491) gpio: GPIO[4]| InputEn: 0| OutputEn: 1| OpenDrain: 1| Pullup: 0| Pulldown: 0| Intr:0 
+I (501) gpio: GPIO[5]| InputEn: 0| OutputEn: 1| OpenDrain: 1| Pullup: 0| Pulldown: 0| Intr:0 
+Found TSL2561 in package T/FN/CL
+Lux: 1245
+Lux: 1252
+Lux: 1250
+Lux: 1248
+Lux: 1248
+Lux: 1247
+...
+```
+
+## Connecting
+
+| `TSL2561` | `ESP8266` | `ESP32` | `NodeMCU` |
+|-----------|-----------|---------|-----------|
+| `SCL`     | `GPIO5`   | `GPIO19`| `D1`      |
+| `SDA`     | `GPIO4`   | `GPIO18`| `D2`      |

--- a/examples/tsl2561/main/main.c
+++ b/examples/tsl2561/main/main.c
@@ -3,14 +3,21 @@
 #include <freertos/task.h>
 #include <esp_system.h>
 #include <tsl2561.h>
+#include <string.h>
 
-#define SDA_GPIO 16
-#define SCL_GPIO 17
+#if defined(CONFIG_IDF_TARGET_ESP8266)
+#define SDA_GPIO 4
+#define SCL_GPIO 5
+#else
+#define SDA_GPIO 18
+#define SCL_GPIO 19
+#endif
 #define ADDR TSL2561_I2C_ADDR_FLOAT
 
 void tsl2561_test(void *pvParamters)
 {
     tsl2561_t dev;
+    memset(&dev, 0, sizeof(tsl2561_t));
 
     ESP_ERROR_CHECK(tsl2561_init_desc(&dev, ADDR, 0, SDA_GPIO, SCL_GPIO));
     ESP_ERROR_CHECK(tsl2561_init(&dev));


### PR DESCRIPTION
with 410 ms, my sensor does not return valid values.

here is the log.

```
D (8216) TSL2561: integration time: 410 ms channel0: 0x0 channel1: 0x0
Lux: 0
```

```
D (7706) TSL2561: integration time: 415 ms channel0: 0x0 channel1: 0x0
Lux: 0
```

```
D (5236) TSL2561: integration time: 420 ms channel0: 0x1992 channel1: 0xa6e
Lux: 1324
```