### PR TITLE
remove travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,8 +109,7 @@ script:
         echo "Building ${i}..."
         cd ${PROJECT_EXAMPLE_DIR}/${i}
         make defconfig
-        # use travis_wait to avoid timeout during the build
-        travis_wait make -j2 >> ${PROJECT_LOG}
+        make -j2 >> ${PROJECT_LOG}
         if [ $? -ne 0 ]; then
           # when failed, show last 100 lines for debugging, and exit with
           # non-zero exit code


### PR DESCRIPTION
looks like it was designed just for simple tasks
https://github.com/travis-ci/travis-ci/issues/7431

besides, the original issue does not exist anymore. fixes #34 