### PR TITLE
lm75: import unit test

### DIFF
--- a/components/lm75/test/CMakeLists.txt
+++ b/components/lm75/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRC_DIRS "."
+                    INCLUDE_DIRS "."
+                    REQUIRES unity lm75)

--- a/components/lm75/test/Makefile
+++ b/components/lm75/test/Makefile
@@ -1,0 +1,33 @@
+# Makefile to build a test application
+#
+# this Makefile injects esp-idf-lib components into esp-idf's component path
+# and builds a unit test application of ESP_IDF_LIB_TEST_CONPONENT_NAME.
+#
+# XXX as of Aug 2019, "Unit Testing in ESP32" omits an important assumption:
+# it is written for esp-idf development, not for users. it does not work
+# because users usually want to test their own components, and the component
+# is not in component path.
+# https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/unit-tests.html
+#
+# XXX also, the example in esp-idf is unnecessarily complicated, and
+# confusing.
+# https://github.com/espressif/esp-idf/blob/master/examples/system/unit_test/README.md
+#
+ESP_IDF_LIB_TEST_CONPONENT_NAME := lm75
+PYTHON_BIN := python2
+
+MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+CURRENT_DIR := $(dir $(MAKEFILE_PATH))
+ESP_IDF_LIB_COMPONENT_DIR := $(CURRENT_DIR)/../../../components
+IDF_PY_EXTRA_ARGS := -DEXTRA_COMPONENT_DIRS=$(ESP_IDF_LIB_COMPONENT_DIR) -DTEST_COMPONENTS=$(ESP_IDF_LIB_TEST_CONPONENT_NAME)
+
+
+build:
+	(cd $(IDF_PATH)/tools/unit-test-app && \
+		$(PYTHON_BIN) $(IDF_PATH)/tools/idf.py build $(IDF_PY_EXTRA_ARGS))
+flash:
+	(cd $(IDF_PATH)/tools/unit-test-app && \
+		$(PYTHON_BIN) $(IDF_PATH)/tools/idf.py flash $(IDF_PY_EXTRA_ARGS))
+clean:
+	(cd $(IDF_PATH)/tools/unit-test-app && \
+		$(PYTHON_BIN) $(IDF_PATH)/tools/idf.py clean)

--- a/components/lm75/test/README.md
+++ b/components/lm75/test/README.md
@@ -1,0 +1,79 @@
+## Makefile to build a test application
+
+This Makefile injects `esp-idf-lib` components into `esp-idf`'s component path and
+builds a unit test application of `ESP_IDF_LIB_TEST_CONPONENT_NAME`.
+
+```
+ets Jun N@!Í5ets Jun  8 2016 00:22:57
+
+rst:0x10 (RTCWDT_RTC_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
+configsip: 0, SPIWP:0xee
+clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
+mode:DIO, clock div:2
+load:0x3fff0018,len:4
+load:0x3fff001c,len:5420
+load:0x40078000,len:10948
+load:0x40080400,len:6312
+entry 0x40080714
+I (94) cpu_start: Pro cpu up.
+I (94) cpu_start: Application information:
+I (94) cpu_start: Project name:     unit-test-app
+I (97) cpu_start: App version:      v4.0-dev-1446-g6b169d473-dirty
+I (103) cpu_start: Compile time:     Aug 27 2019 16:37:49
+I (110) cpu_start: ELF file SHA256:  fde49b40c6d48ad8...
+I (116) cpu_start: ESP-IDF:          v4.0-dev-1446-g6b169d473-dirty
+I (122) cpu_start: Starting app cpu, entry point is 0x40081034
+I (0) cpu_start: App cpu up.
+I (133) heap_init: Initializing. RAM available for dynamic allocation:
+I (140) heap_init: At 3FFAE6E0 len 00001920 (6 KiB): DRAM
+I (147) heap_init: At 3FFB3580 len 0002CA80 (178 KiB): DRAM
+I (152) heap_init: At 3FFE0440 len 00003AE0 (14 KiB): D/IRAM
+I (158) heap_init: At 3FFE4350 len 0001BCB0 (111 KiB): D/IRAM
+I (167) heap_init: At 4008A1E8 len 00015E18 (87 KiB): IRAM
+I (171) cpu_start: Pro cpu start user code
+I (189) efuse: Loading virtual efuse blocks from real efuses
+I (190) spi_flash: detected chip: generic
+I (190) spi_flash: flash io: dio
+I (194) cpu_start: Starting scheduler on PRO CPU.
+I (0) cpu_start: Starting scheduler on APP CPU.
+
+
+Press ENTER to see the list of tests.
+
+
+Here's the test menu, pick your combo:
+(1)	"a silly test" [lm75]
+
+Enter test for running.
+Running a silly test...
+/usr/home/trombik/github/trombik/esp-idf-lib/components/lm75/test/test_lm75.c:4:a silly test:PASS
+Test ran in 25ms
+
+-----------------------
+1 Tests 0 Failures 0 Ignored
+OK
+Enter next test, or 'enter' to see menu
+```
+
+## Usage
+
+Build the test application:
+
+```
+make build
+```
+
+Flash the application (make sure `ESPPORT` environment variable is defined):
+
+```
+make flash
+```
+
+Then, open serial console and type the number of test to execute. Note that
+keyboard input is not echoed back.
+
+Clean:
+
+```
+make clean
+```

--- a/components/lm75/test/component.mk
+++ b/components/lm75/test/component.mk
@@ -1,0 +1,4 @@
+#
+# Component Makefile
+#
+COMPONENT_ADD_LDFLAGS = -Wl,--whole-archive -l$(COMPONENT_NAME) -Wl,--no-whole-archive

--- a/components/lm75/test/test_lm75.c
+++ b/components/lm75/test/test_lm75.c
@@ -1,0 +1,8 @@
+#include <unity.h>
+#include "lm75.h"
+
+TEST_CASE("a silly test", "[lm75]")
+{
+    TEST_ASSERT_EQUAL(1, 1);
+}
+


### PR DESCRIPTION
finally, I figured out how to run unit tests in component development.
There are lots of undocumented pitfalls.

with the Makefile under `test` directory, you can run unit tests on a
real device. currently, the test file has a meaningless unit test. for
now, it is written for reference purpose only.

tested on ESP32.