### PR TITLE
ds1307: Fix SQWEF_MASK bit mask

### DIFF
--- a/components/ds1307/ds1307.c
+++ b/components/ds1307/ds1307.c
@@ -30,7 +30,7 @@
 #define SECONDS_MASK 0x7f
 #define HOUR12_MASK  0x1f
 #define HOUR24_MASK  0x3f
-#define SQWEF_MASK   0x03
+#define SQWEF_MASK   0xfc
 #define SQWE_MASK    0xef
 #define OUT_MASK     0x7f
 


### PR DESCRIPTION
I worked with ds1307 in and found, that the timer signal is configures incorrectly. The reason, turned out to be that the bit mask for the RS1:RS0 bits in the control register (0x07) sets incorrectly.
Other masks in this file look ok.