### PR TITLE
bugfix: include esp_err.h in header files

### DIFF
--- a/components/ads111x/ads111x.h
+++ b/components/ads111x/ads111x.h
@@ -15,6 +15,7 @@
 #define __ADS111X_H__
 
 #include <stdbool.h>
+#include <esp_err.h>
 #include <i2cdev.h>
 
 #ifdef __cplusplus

--- a/components/bh1750/bh1750.h
+++ b/components/bh1750/bh1750.h
@@ -20,6 +20,7 @@
 
 #include <stdint.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/bme680/bme680.h
+++ b/components/bme680/bme680.h
@@ -17,6 +17,7 @@
 
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/bmp180/bmp180.h
+++ b/components/bmp180/bmp180.h
@@ -17,6 +17,7 @@
 
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #define BMP180_DEVICE_ADDRESS 0x77 //!< I2C address
 

--- a/components/dht/dht.h
+++ b/components/dht/dht.h
@@ -19,6 +19,7 @@
 #define __DHT_H__
 
 #include <driver/gpio.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/ds1302/ds1302.h
+++ b/components/ds1302/ds1302.h
@@ -18,6 +18,7 @@
 #include <stdbool.h>
 #include <driver/gpio.h>
 #include <time.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/ds1307/ds1307.h
+++ b/components/ds1307/ds1307.h
@@ -17,6 +17,7 @@
 #include <stdbool.h>
 #include <time.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/ds18x20/ds18x20.h
+++ b/components/ds18x20/ds18x20.h
@@ -16,6 +16,7 @@
 #ifndef __DS18X20_H__
 #define __DS18X20_H__
 
+#include <esp_err.h>
 #include <onewire.h>
 
 #ifdef __cplusplus

--- a/components/ds3231/ds3231.h
+++ b/components/ds3231/ds3231.h
@@ -19,6 +19,7 @@
 #include <time.h>
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef	__cplusplus
 extern "C" {

--- a/components/hd44780/hd44780.h
+++ b/components/hd44780/hd44780.h
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <driver/gpio.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/hmc5883l/hmc5883l.h
+++ b/components/hmc5883l/hmc5883l.h
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/hx711/hx711.h
+++ b/components/hx711/hx711.h
@@ -14,6 +14,7 @@
 
 #include <driver/gpio.h>
 #include <stdbool.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/i2cdev/i2cdev.h
+++ b/components/i2cdev/i2cdev.h
@@ -15,6 +15,7 @@
 #include <driver/i2c.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/ina219/ina219.h
+++ b/components/ina219/ina219.h
@@ -14,6 +14,7 @@
 #define __INA219_H__
 
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/ina3221/ina3221.h
+++ b/components/ina3221/ina3221.h
@@ -17,6 +17,7 @@
 
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/lm75/lm75.h
+++ b/components/lm75/lm75.h
@@ -40,6 +40,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/max31725/max31725.h
+++ b/components/max31725/max31725.h
@@ -14,6 +14,7 @@
 
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #define MAX31725_I2C_ADDR_BASE 0x40 //!< See full list in datasheet
 

--- a/components/max7219/max7219.h
+++ b/components/max7219/max7219.h
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 #include <driver/spi_master.h>
 #include <driver/gpio.h> // add by nopnop2002
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/mcp23008/mcp23008.h
+++ b/components/mcp23008/mcp23008.h
@@ -14,6 +14,7 @@
 
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #define MCP23008_I2C_ADDR_BASE 0x20
 

--- a/components/mcp23x17/mcp23x17.h
+++ b/components/mcp23x17/mcp23x17.h
@@ -17,6 +17,7 @@
 #include <i2cdev.h>
 #include <driver/spi_master.h>
 #include <driver/gpio.h>
+#include <esp_err.h>
 
 #define MCP23X17_ADDR_BASE 0x20
 

--- a/components/mcp4725/mcp4725.h
+++ b/components/mcp4725/mcp4725.h
@@ -16,6 +16,7 @@
 
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/ms5611/ms5611.h
+++ b/components/ms5611/ms5611.h
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/pca9685/pca9685.h
+++ b/components/pca9685/pca9685.h
@@ -16,6 +16,7 @@
 
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/pcf8574/pcf8574.h
+++ b/components/pcf8574/pcf8574.h
@@ -14,6 +14,7 @@
 
 #include <stddef.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/pcf8575/pcf8575.h
+++ b/components/pcf8575/pcf8575.h
@@ -14,6 +14,7 @@
 
 #include <stddef.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/pcf8591/pcf8591.h
+++ b/components/pcf8591/pcf8591.h
@@ -17,6 +17,7 @@
 #define __PCF8591_H__
 
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/qmc5883l/qmc5883l.h
+++ b/components/qmc5883l/qmc5883l.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/sht3x/sht3x.h
+++ b/components/sht3x/sht3x.h
@@ -17,6 +17,7 @@
 
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/si7021/si7021.h
+++ b/components/si7021/si7021.h
@@ -15,6 +15,7 @@
 
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/tca95x5/tca95x5.h
+++ b/components/tca95x5/tca95x5.h
@@ -14,6 +14,7 @@
 
 #include <stddef.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/tda74xx/tda74xx.h
+++ b/components/tda74xx/tda74xx.h
@@ -14,6 +14,7 @@
 
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/tsl2561/tsl2561.h
+++ b/components/tsl2561/tsl2561.h
@@ -17,6 +17,7 @@
 #define __TSL2561_H__
 
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/tsl4531/tsl4531.h
+++ b/components/tsl4531/tsl4531.h
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <i2cdev.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/components/ultrasonic/ultrasonic.h
+++ b/components/ultrasonic/ultrasonic.h
@@ -15,6 +15,7 @@
 #define __ULTRASONIC_H__
 
 #include <driver/gpio.h>
+#include <esp_err.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
where `esp_err_t` is used