### PR TITLE
mcp23x17.c: Fix broken SPI device addressing

### DIFF
--- a/components/mcp23x17/mcp23x17.c
+++ b/components/mcp23x17/mcp23x17.c
@@ -127,7 +127,7 @@ static esp_err_t read_reg_16(mcp23x17_t *dev, uint8_t reg, uint16_t *val)
     CHECK_ARG(dev && val);
 
     uint8_t rx[4] = { 0 };
-    uint8_t tx[4] = { dev->addr, reg, 0, 0 };
+    uint8_t tx[4] = { (dev->addr << 1) | 0x01, reg, 0, 0 };
 
     spi_transaction_t t;
     memset(&t, 0, sizeof(spi_transaction_t));
@@ -146,7 +146,7 @@ static esp_err_t write_reg_16(mcp23x17_t *dev, uint8_t reg, uint16_t val)
 {
     CHECK_ARG(dev);
 
-    uint8_t tx[4] = { dev->addr, reg, val, val >> 8 };
+    uint8_t tx[4] = { dev->addr << 1, reg, val, val >> 8 };
 
     spi_transaction_t t;
     memset(&t, 0, sizeof(spi_transaction_t));
@@ -173,7 +173,7 @@ static esp_err_t read_reg_8(mcp23x17_t *dev, uint8_t reg, uint8_t *val)
     CHECK_ARG(dev && val);
 
     uint8_t rx[3] = { 0 };
-    uint8_t tx[3] = { dev->addr, reg, 0 };
+    uint8_t tx[3] = { (dev->addr << 1) | 0x01, reg, 0 };
 
     spi_transaction_t t;
     memset(&t, 0, sizeof(spi_transaction_t));
@@ -192,7 +192,7 @@ static esp_err_t write_reg_8(mcp23x17_t *dev, uint8_t reg, uint8_t val)
 {
     CHECK_ARG(dev);
 
-    uint8_t tx[3] = { dev->addr, reg, val };
+    uint8_t tx[3] = { dev->addr << 1, reg, val };
 
     spi_transaction_t t;
     memset(&t, 0, sizeof(spi_transaction_t));


### PR DESCRIPTION
The MCP23S17 expects the 7-bit device address and a read/write bit
in the first byte of each transfer. Currently only the address is
sent. Fix this by shifting the address by one bit to the left and add
set the R/W bit if necessary.