### PR TITLE
Fix incorrect implementation of tm structure

### DIFF
--- a/components/ds1302/ds1302.c
+++ b/components/ds1302/ds1302.c
@@ -250,7 +250,7 @@ esp_err_t ds1302_get_time(ds1302_t *dev, struct tm *time)
     time->tm_mday = bcd2dec(buf[3]);
     time->tm_mon  = bcd2dec(buf[4]) - 1;
     time->tm_wday = bcd2dec(buf[5]) - 1;
-    time->tm_year = bcd2dec(buf[6]) + 2000;
+    time->tm_year = bcd2dec(buf[6]) + 100;
 
     return ESP_OK;
 }
@@ -266,7 +266,7 @@ esp_err_t ds1302_set_time(ds1302_t *dev, const struct tm *time)
         dec2bcd(time->tm_mday),
         dec2bcd(time->tm_mon  + 1),
         dec2bcd(time->tm_wday + 1),
-        dec2bcd(time->tm_year - 2000),
+        dec2bcd(time->tm_year - 100),
         0
     };
     return burst_write(dev, CLOCK_BURST, buf, 8);

--- a/components/ds1307/ds1307.c
+++ b/components/ds1307/ds1307.c
@@ -127,7 +127,7 @@ esp_err_t ds1307_get_time(i2c_dev_t *dev, struct tm *time)
     time->tm_wday = bcd2dec(buf[3]) - 1;
     time->tm_mday = bcd2dec(buf[4]);
     time->tm_mon  = bcd2dec(buf[5]) - 1;
-    time->tm_year = bcd2dec(buf[6]) + 2000;
+    time->tm_year = bcd2dec(buf[6]) + 100;
 
     return ESP_OK;
 }
@@ -143,7 +143,7 @@ esp_err_t ds1307_set_time(i2c_dev_t *dev, const struct tm *time)
         dec2bcd(time->tm_wday + 1),
         dec2bcd(time->tm_mday),
         dec2bcd(time->tm_mon + 1),
-        dec2bcd(time->tm_year - 2000)
+        dec2bcd(time->tm_year - 100)
     };
 
     I2C_DEV_TAKE_MUTEX(dev);

--- a/components/ds3231/ds3231.c
+++ b/components/ds3231/ds3231.c
@@ -98,7 +98,7 @@ esp_err_t ds3231_set_time(i2c_dev_t *dev, struct tm *time)
     data[3] = dec2bcd(time->tm_wday + 1);
     data[4] = dec2bcd(time->tm_mday);
     data[5] = dec2bcd(time->tm_mon + 1);
-    data[6] = dec2bcd(time->tm_year - 2000);
+    data[6] = dec2bcd(time->tm_year - 100);
 
     I2C_DEV_TAKE_MUTEX(dev);
     I2C_DEV_CHECK(dev, i2c_dev_write_reg(dev, DS3231_ADDR_TIME, data, 7));
@@ -388,7 +388,7 @@ esp_err_t ds3231_get_time(i2c_dev_t *dev, struct tm *time)
     time->tm_wday = bcd2dec(data[3]) - 1;
     time->tm_mday = bcd2dec(data[4]);
     time->tm_mon  = bcd2dec(data[5] & DS3231_MONTH_MASK) - 1;
-    time->tm_year = bcd2dec(data[6]) + 2000;
+    time->tm_year = bcd2dec(data[6]) + 100;
     time->tm_isdst = 0;
 
     // apply a time zone (if you are not using localtime on the rtc or you want to check/apply DST)

--- a/examples/ds1302/main/main.c
+++ b/examples/ds1302/main/main.c
@@ -26,7 +26,7 @@ void ds1302_test(void *pvParameters)
 
     // setup datetime: 2018-04-11 00:52:10
     struct tm time = {
-        .tm_year = 2018,
+        .tm_year = 118, //year since 1900 (2018 - 1900)
         .tm_mon  = 3,  // 0-based
         .tm_mday = 11,
         .tm_hour = 0,
@@ -40,7 +40,7 @@ void ds1302_test(void *pvParameters)
     {
         ds1302_get_time(&dev, &time);
 
-        printf("%04d-%02d-%02d %02d:%02d:%02d\n", time.tm_year, time.tm_mon + 1,
+        printf("%04d-%02d-%02d %02d:%02d:%02d\n", time.tm_year + 1900 /*Add 1900 for better readability*/, time.tm_mon + 1,
             time.tm_mday, time.tm_hour, time.tm_min, time.tm_sec);
 
         vTaskDelay(500 / portTICK_PERIOD_MS);

--- a/examples/ds1307/main/main.c
+++ b/examples/ds1307/main/main.c
@@ -21,7 +21,7 @@ void ds1307_test(void *pvParameters)
 
     // setup datetime: 2018-04-11 00:52:10
     struct tm time = {
-        .tm_year = 2018,
+        .tm_year = 118, //since 1900 (2018 - 1900)
         .tm_mon  = 3,  // 0-based
         .tm_mday = 11,
         .tm_hour = 0,
@@ -34,7 +34,7 @@ void ds1307_test(void *pvParameters)
     {
         ds1307_get_time(&dev, &time);
 
-        printf("%04d-%02d-%02d %02d:%02d:%02d\n", time.tm_year, time.tm_mon + 1,
+        printf("%04d-%02d-%02d %02d:%02d:%02d\n", time.tm_year + 1900 /*Add 1900 for better readability*/, time.tm_mon + 1,
             time.tm_mday, time.tm_hour, time.tm_min, time.tm_sec);
 
         vTaskDelay(500 / portTICK_PERIOD_MS);

--- a/examples/ds3231/main/main.c
+++ b/examples/ds3231/main/main.c
@@ -21,7 +21,7 @@ void ds3231_test(void *pvParameters)
 
     // setup datetime: 2016-10-09 13:50:10
     struct tm time = {
-        .tm_year = 2016,
+        .tm_year = 116, //since 1900 (2016 - 1900)
         .tm_mon  = 9,  // 0-based
         .tm_mday = 9,
         .tm_hour = 13,
@@ -52,7 +52,7 @@ void ds3231_test(void *pvParameters)
          * sdkconfig for ESP8266, which is enabled by default for this
          * example. see sdkconfig.defaults.esp8266
          */
-        printf("%04d-%02d-%02d %02d:%02d:%02d, %.2f deg Cel\n", time.tm_year, time.tm_mon + 1,
+        printf("%04d-%02d-%02d %02d:%02d:%02d, %.2f deg Cel\n", time.tm_year + 1900 /*Add 1900 for better readability*/, time.tm_mon + 1,
             time.tm_mday, time.tm_hour, time.tm_min, time.tm_sec, temp);
     }
 }


### PR DESCRIPTION
Fixes #76
This problem caused mktime to return wrong values

According to official (http://www.cplusplus.com/reference/ctime/tm/) documentation the tm structure is supposed to store year since 1900 instead of absolute year