### PR TITLE
Bugfix for overflow issue in get_time_us function (sht3x.c).

### DIFF
--- a/components/sht3x/sht3x.c
+++ b/components/sht3x/sht3x.c
@@ -68,7 +68,7 @@ static uint32_t get_time_us()
 {
     struct timeval time;
     gettimeofday(&time, 0);
-    return time.tv_sec * 1e6 + time.tv_usec;
+    return (uint32_t)(time.tv_sec * 1e6) + (uint32_t)time.tv_usec;
 }
 
 #define G_POLYNOM 0x31


### PR DESCRIPTION
When max uint32_t was reached, return value didn't overflow, but was kept at max uint32_t causing the SHT3x I2C device to abort reading measurement value (due to a check in sht3x_is_measuring function).

This was found using ESP8266_RTOS_SDK and the latest ESP8266 xtensa compiler. It might be different using ESP32...

Issue seems to exist a few more places in the esp-idf-lib (searching for gettimeofday usage), but I don't have the specific sensors, so I haven't made any modifications to those locations...

Best regards
Brian
