### PR TITLE
Fix bme680 example for check on bme680_get_results_float() fct

### DIFF
--- a/examples/bme680/main/main.c
+++ b/examples/bme680/main/main.c
@@ -50,7 +50,7 @@ void bme680_test(void *pvParamters)
             vTaskDelay(duration);
 
             // get the results and do something with them
-            if (bme680_get_results_float(&sensor, &values))
+            if (bme680_get_results_float(&sensor, &values) == ESP_OK)
                 printf("BME680 Sensor: %.2f °C, %.2f %%, %.2f hPa, %.2f Ohm\n",
                         values.temperature, values.humidity, values.pressure, values.gas_resistance);
         }


### PR DESCRIPTION
Example not working otherwise. 

With this fix, the code suits the documentation on https://esp-idf-lib.readthedocs.io/en/latest/groups/bme680.html#measurement-cylce