### PR TITLE
Remove additional start in ultrasonic timeout

### DIFF
--- a/components/ultrasonic/ultrasonic.c
+++ b/components/ultrasonic/ultrasonic.c
@@ -77,7 +77,7 @@ esp_err_t ultrasonic_measure_cm(const ultrasonic_sensor_t *dev, uint32_t max_dis
     // got echo, measuring
     int64_t echo_start = esp_timer_get_time();
     int64_t time = echo_start;
-    int64_t meas_timeout = echo_start + max_distance * ROUNDTRIP;
+    int64_t meas_timeout = max_distance * ROUNDTRIP;
     while (gpio_get_level(dev->echo_pin))
     {
         time = esp_timer_get_time();


### PR DESCRIPTION
I've come across an issue where the timeout isn't firing for the ultrasonic component when going over the max distance. I think this is because `meas_timeout` is currently `echo_start + max_distance * ROUNDTRIP` which is then compared with `timeout_expired(echo_start, meas_timeout)`. This macro expands to:

```
((esp_timer_get_time() - (echo_start)) >= (echo_start + max_distance * ROUNDTRIP))
```

By removing the `echo_start` it should instead expand to:

```
((esp_timer_get_time() - (echo_start)) >= (max_distance * ROUNDTRIP))
```