### PR TITLE
bugfix: fetch all the history of submodules, fixes #134

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -403,6 +403,9 @@ jobs:
           path: idf
           submodules: recursive
           ref: ${{ matrix.branch }}
+          # XXX git.eclipse.org does not allow to fetch a commit. fetch all
+          # the commits.
+          fetch-depth: 0
 
       - name: Install python requirements (pip)
         if: ${{ ! startsWith(matrix.branch, 'v3.3') }}


### PR DESCRIPTION
https://github.com/UncleRus/esp-idf-lib/runs/1448799077

Submodule path 'components/coap/libcoap': checked out 'cfec0d072c5b99ed3e54828ca50ea2f6b91e1f50'
Submodule 'ext/tinydtls' (https://git.eclipse.org/r/tinydtls/org.eclipse.tinydtls) registered for path 'components/coap/libcoap/ext/tinydtls'
Cloning into '/home/runner/work/esp-idf-lib/esp-idf-lib/idf/components/coap/libcoap/ext/tinydtls'...
Error: error: Server does not allow request for unadvertised object 3b24a701ed5b0785306aa732e739ecb1eb3d03f8
Fetched in submodule path 'components/coap/libcoap/ext/tinydtls', but it did not contain 3b24a701ed5b0785306aa732e739ecb1eb3d03f8. Direct fetching of that commit failed.