### PR TITLE
Typo corrections + SHT3x corrections and improvement

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -106,7 +106,7 @@ ESP_ERROR_CHECK(ads111x_init_desc(&dev, addr, I2C_PORT, SDA_GPIO, SCL_GPIO));
     dev.cfg.master.clk_speed = 100000; // Hz
 #endif
 
-ESP_ERROR_CHECK(ads111x_set_mode(&dev, ADS111X_MODE_CONTINUOS));    // Continuous conversion mode
+ESP_ERROR_CHECK(ads111x_set_mode(&dev, ADS111X_MODE_CONTINUOUS));    // Continuous conversion mode
 ESP_ERROR_CHECK(ads111x_set_data_rate(&dev, ADS111X_DATA_RATE_32)); // 32 samples per second
 ...
 ```

--- a/components/ads111x/ads111x.h
+++ b/components/ads111x/ads111x.h
@@ -95,7 +95,7 @@ typedef enum
  */
 typedef enum
 {
-    ADS111X_MODE_CONTINUOS = 0, //!< Continuous conversion mode
+    ADS111X_MODE_CONTINUOUS = 0, //!< Continuous conversion mode
     ADS111X_MODE_SINGLE_SHOT    //!< Power-down single-shot mode (default)
 } ads111x_mode_t;
 
@@ -138,7 +138,7 @@ typedef enum
 } ads111x_comp_queue_t;
 
 /**
- * Initialize device descriptior
+ * Initialize device descriptor
  * @param dev Device descriptor
  * @param addr Device address
  * @param port I2C port number

--- a/components/bh1750/bh1750.c
+++ b/components/bh1750/bh1750.c
@@ -100,7 +100,7 @@ esp_err_t bh1750_setup(i2c_dev_t *dev, bh1750_mode_t mode, bh1750_resolution_t r
 {
     CHECK_ARG(dev);
 
-    uint8_t opcode = mode == BH1750_MODE_CONTINIOUS ? OPCODE_CONT : OPCODE_OT;
+    uint8_t opcode = mode == BH1750_MODE_CONTINUOUS ? OPCODE_CONT : OPCODE_OT;
     switch (resolution)
     {
         case BH1750_RES_LOW:  opcode |= OPCODE_LOW;   break;

--- a/components/bh1750/bh1750.h
+++ b/components/bh1750/bh1750.h
@@ -35,7 +35,7 @@ extern "C" {
 typedef enum
 {
     BH1750_MODE_ONE_TIME = 0, //!< One time measurement
-    BH1750_MODE_CONTINIOUS    //!< Continious measurement
+    BH1750_MODE_CONTINUOUS    //!< Continuous measurement
 } bh1750_mode_t;
 
 /**
@@ -49,7 +49,7 @@ typedef enum
 } bh1750_resolution_t;
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  * @param[out] dev Pointer to device descriptor
  * @param[in] addr I2C address, BH1750_ADDR_LO or BH1750_ADDR_HI
  * @param[in] port I2C port number

--- a/components/bmp180/bmp180.c
+++ b/components/bmp180/bmp180.c
@@ -55,7 +55,7 @@ static esp_err_t bmp180_read_reg_16(i2c_dev_t *dev, uint8_t reg, int16_t *r)
     return ESP_OK;
 }
 
-static inline esp_err_t bmp180_start_messurement(i2c_dev_t *dev, uint8_t cmd)
+static inline esp_err_t bmp180_start_measurement(i2c_dev_t *dev, uint8_t cmd)
 {
     return i2c_dev_write_reg(dev, BMP180_CONTROL_REG, &cmd, 1);
 }
@@ -63,7 +63,7 @@ static inline esp_err_t bmp180_start_messurement(i2c_dev_t *dev, uint8_t cmd)
 static esp_err_t bmp180_get_uncompensated_temperature(i2c_dev_t *dev, int32_t *ut)
 {
     // Write Start Code into reg 0xF4.
-    CHECK(bmp180_start_messurement(dev, BMP180_MEASURE_TEMP));
+    CHECK(bmp180_start_measurement(dev, BMP180_MEASURE_TEMP));
 
     // Wait 5ms, datasheet states 4.5ms
     ets_delay_us(5000);
@@ -89,7 +89,7 @@ static esp_err_t bmp180_get_uncompensated_pressure(i2c_dev_t *dev, bmp180_mode_t
     }
 
     // Write Start Code into reg 0xF4
-    CHECK(bmp180_start_messurement(dev, BMP180_MEASURE_PRESS | (oss << 6)));
+    CHECK(bmp180_start_measurement(dev, BMP180_MEASURE_PRESS | (oss << 6)));
 
     ets_delay_us(us);
 

--- a/components/bmp180/bmp180.h
+++ b/components/bmp180/bmp180.h
@@ -61,7 +61,7 @@ typedef enum
 
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  *
  * @param[out] dev Pointer to device descriptor
  * @param port I2C port number

--- a/components/bmp280/bmp280.h
+++ b/components/bmp280/bmp280.h
@@ -116,7 +116,7 @@ typedef struct {
 } bmp280_t;
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  * @param[out] dev Pointer to device descriptor
  * @param[in] addr BMP280 address
  * @param[in] port I2C port number
@@ -136,7 +136,7 @@ esp_err_t bmp280_free_desc(bmp280_t *dev);
 /**
  * Initialize default parameters.
  * Default configuration:
- *      mode: NORAML
+ *      mode: NORMAL
  *      filter: OFF
  *      oversampling: x4
  *      standby time: 250ms
@@ -173,7 +173,7 @@ esp_err_t bmp280_is_measuring(bmp280_t *dev, bool *busy);
  *  Pressure in Pascals in fixed point 24 bit integer 8 bit fraction format.
  *
  *  Humidity is optional and only read for the BME280, in percent relative
- *  humidity as a fixed point 22 bit interger and 10 bit fraction format.
+ *  humidity as a fixed point 22 bit integer and 10 bit fraction format.
  */
 esp_err_t bmp280_read_fixed(bmp280_t *dev, int32_t *temperature,
                             uint32_t *pressure, uint32_t *humidity);

--- a/components/dht/dht.c
+++ b/components/dht/dht.c
@@ -46,7 +46,7 @@
  *  of length 5.  The first and third bytes are humidity (%) and temperature (C), respectively.  Bytes 2 and 4
  *  are zero-filled and the fifth is a checksum such that:
  *
- *  byte_5 == (byte_1 + byte_2 + byte_3 + btye_4) & 0xFF
+ *  byte_5 == (byte_1 + byte_2 + byte_3 + byte_4) & 0xFF
  *
  */
 

--- a/components/ds3231/ds3231.h
+++ b/components/ds3231/ds3231.h
@@ -116,7 +116,7 @@ esp_err_t ds3231_get_time(i2c_dev_t *dev, struct tm *time);
  * and you can set both alarms at the same time (pass `DS3231_ALARM_1`/`DS3231_ALARM_2`/`DS3231_ALARM_BOTH`).
  *
  * If only setting one alarm just pass 0 for `tm` struct and `option` field for the other alarm.
- * If using `DS3231_ALARM1_EVERY_SECOND`/`DS3231_ALARM2_EVERY_MIN` you can pass 0 for `tm` stuct.
+ * If using `DS3231_ALARM1_EVERY_SECOND`/`DS3231_ALARM2_EVERY_MIN` you can pass 0 for `tm` struct.
  *
  * If you want to enable interrupts for the alarms you need to do that separately.
  *

--- a/components/hd44780/hd44780.c
+++ b/components/hd44780/hd44780.c
@@ -1,7 +1,7 @@
 /**
  * @file hd44780.c
  *
- * ESP-IDF driver for HD44780 compartible LCD text displays
+ * ESP-IDF driver for HD44780 compatible LCD text displays
  *
  * Ported from esp-open-rtos
  *

--- a/components/hd44780/hd44780.h
+++ b/components/hd44780/hd44780.h
@@ -3,7 +3,7 @@
  * @defgroup hd44780 hd44780
  * @{
  *
- * ESP-IDF driver for HD44780 compartible LCD text displays
+ * ESP-IDF driver for HD44780 compatible LCD text displays
  *
  * Ported from esp-open-rtos
  *

--- a/components/hmc5883l/hmc5883l.h
+++ b/components/hmc5883l/hmc5883l.h
@@ -117,7 +117,7 @@ typedef struct
 } hmc5883l_data_t;
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  * @param dev Pointer to device descriptor
  * @param port I2C port number
  * @param sda_gpio GPIO pin number for SDA

--- a/components/hx711/hx711.h
+++ b/components/hx711/hx711.h
@@ -88,7 +88,7 @@ esp_err_t hx711_wait(hx711_t *dev, size_t timeout_ms);
  * @brief Read raw data from device.
  *
  * Please call this function only when device is ready,
- * otherwise communictaion errors may occur
+ * otherwise communication errors may occur
  *
  * @param dev Device descriptor
  * @param data Raw ADC data

--- a/components/i2cdev/i2cdev.h
+++ b/components/i2cdev/i2cdev.h
@@ -95,7 +95,7 @@ esp_err_t i2c_dev_give_mutex(i2c_dev_t *dev);
 /**
  * @brief Read from slave device
  *
- * Issue a send operation of \p out_data register adress, followed by reading \p in_size bytes
+ * Issue a send operation of \p out_data register address, followed by reading \p in_size bytes
  * from slave into \p in_data .
  * Function is thread-safe.
  * @param[in] dev Device descriptor

--- a/components/ina260/ina260.h
+++ b/components/ina260/ina260.h
@@ -149,7 +149,7 @@ esp_err_t ina260_reset(ina260_t *dev);
  *
  * @param dev Device descriptor
  * @param mode Operating mode
- * @param avg_mode Averaging mide
+ * @param avg_mode Averaging mode
  * @param vbus_ct Bus voltage conversion time
  * @param ish_ct Shunt current conversion time
  * @return `ESP_OK` on success
@@ -162,7 +162,7 @@ esp_err_t ina260_set_config(ina260_t *dev, ina260_mode_t mode, ina260_averaging_
  *
  * @param dev Device descriptor
  * @param[out] mode Operating mode
- * @param[out] avg_mode Averaging mide
+ * @param[out] avg_mode Averaging mode
  * @param[out] vbus_ct Bus voltage conversion time
  * @param[out] ish_ct Shunt current conversion time
  * @return `ESP_OK` on success

--- a/components/ina3221/ina3221.h
+++ b/components/ina3221/ina3221.h
@@ -89,7 +89,7 @@ typedef union
     {
         uint16_t esht :1; ///< Enable/Disable shunt measure    // LSB
         uint16_t ebus :1; ///< Enable/Disable bus measure
-        uint16_t mode :1; ///< Single shot measure or continious mode
+        uint16_t mode :1; ///< Single shot measure or continuous mode
         uint16_t vsht :3; ///< Shunt voltage conversion time
         uint16_t vbus :3; ///< Bus voltage conversion time
         uint16_t avg  :3; ///< number of sample collected and averaged together

--- a/components/lm75/lm75.c
+++ b/components/lm75/lm75.c
@@ -82,7 +82,7 @@ esp_err_t lm75_read_temperature(i2c_dev_t *dev, float *value)
 
     I2C_DEV_TAKE_MUTEX(dev);
     CHECK_LOGE(dev, read_register16(dev, LM75_REG_TEMP, &raw_data),
-            "lm75_read_temperature(): read_register16() failed: regsiter: 0x%x", LM75_REG_TEMP);
+            "lm75_read_temperature(): read_register16() failed: register: 0x%x", LM75_REG_TEMP);
     I2C_DEV_GIVE_MUTEX(dev);
 
     *value = (raw_data >> 5) * 0.125;
@@ -144,7 +144,7 @@ esp_err_t lm75_get_os_threshold(i2c_dev_t *dev, float *value)
 
     I2C_DEV_TAKE_MUTEX(dev);
     CHECK_LOGE(dev, read_register16(dev, LM75_REG_TOS, &reg_value),
-            "lm75_get_os_threshold(): read_register16() failed: regsiter: 0x%x", LM75_REG_TOS);
+            "lm75_get_os_threshold(): read_register16() failed: register: 0x%x", LM75_REG_TOS);
     I2C_DEV_GIVE_MUTEX(dev);
 
     ESP_LOGV(TAG, "lm75_get_os_threshold(): reg_value: 0x%x 9 bit reg_value: 0x%x", reg_value, reg_value >> 7);
@@ -205,7 +205,7 @@ esp_err_t lm75_clear_bits_register8(i2c_dev_t *dev, uint8_t reg, uint8_t mask)
         value ^= mask;
         ESP_LOGV(TAG, "lm75_clear_bits_register8(): updating register with value: 0x%x", value);
         CHECK_LOGE(dev, write_register8(dev, reg, value),
-                "write_register8() failed: regsiter 0x%x", reg);
+                "write_register8() failed: register 0x%x", reg);
     } else {
         ESP_LOGV(TAG, "lm75_clear_bits_register8(): register unchanged");
     }

--- a/components/lm75/lm75.h
+++ b/components/lm75/lm75.h
@@ -28,8 +28,8 @@
  * Short usage instruction:
  *
  * 1. Include lm75.h
- * 2. Initialize I2C descriptior by i2cdev_init()
- * 3. Initialize LM75 descriptior by lm75_init_desc()
+ * 2. Initialize I2C descriptor by i2cdev_init()
+ * 3. Initialize LM75 descriptor by lm75_init_desc()
  * 4. Initialize LM75 by lm75_init()
  * 5. Read temperature by lm75_read_temperature()
  *
@@ -95,11 +95,11 @@ typedef struct {
 } lm75_config_t;
 
 /**
- * @brief Initialize LM75 device descriptior
+ * @brief Initialize LM75 device descriptor
  *
  * i2cdev_init() must be called before this function.
  *
- * @param[out] dev pointer to LM75 device descriptior
+ * @param[out] dev pointer to LM75 device descriptor
  * @param[in] addr I2C address of LM75
  * @param[in] port I2C port
  * @param[in] sda_gpio GPIO number of SDA
@@ -113,20 +113,20 @@ esp_err_t lm75_init_desc(i2c_dev_t *dev, uint8_t addr, i2c_port_t port, gpio_num
  *
  * lm75_init_desc() must be called before this function.
  *
- * @param[in] dev pointer to LM75 device descriptior
+ * @param[in] dev pointer to LM75 device descriptor
  * @param[in] config configuration
  */
 esp_err_t lm75_init(i2c_dev_t *dev, const lm75_config_t config);
 
 /**
- * @brief free LM75 device descriptior
+ * @brief free LM75 device descriptor
  * @param dev Pointer to device descriptor
  */
 esp_err_t lm75_free_desc(i2c_dev_t *dev);
 
 /**
  * @brief Get the value of OS Polarity in the configuration register
- * @param[in] dev pointer to LM75 device descriptior
+ * @param[in] dev pointer to LM75 device descriptor
  * @param[out] v value of OS Polarity
  * @return `ESP_OK` on success
  */
@@ -134,7 +134,7 @@ esp_err_t lm75_get_os_polarity(i2c_dev_t *dev, uint8_t *v);
 
 /**
  * @brief Get the value of OS threshold in the configuration register
- * @param[in] dev pointer to LM75 device descriptior
+ * @param[in] dev pointer to LM75 device descriptor
  * @param[out] value value of OS threshold
  * @return `ESP_OK` on success
  */
@@ -142,7 +142,7 @@ esp_err_t lm75_get_os_threshold(i2c_dev_t *dev, float *value);
 
 /**
  * @brief Read the temperature
- * @param[in] dev pointer to LM75 device descriptior
+ * @param[in] dev pointer to LM75 device descriptor
  * @param[out] value temperature
  * @return `ESP_OK` on success
  */
@@ -150,7 +150,7 @@ esp_err_t lm75_read_temperature(i2c_dev_t *dev, float *value);
 
 /**
  * @brief Set OS mode
- * @param[in] dev pointer to LM75 device descriptior
+ * @param[in] dev pointer to LM75 device descriptor
  * @param[in] v OS mode
  * @return `ESP_OK` on success
  */
@@ -159,7 +159,7 @@ esp_err_t lm75_set_os_mode(i2c_dev_t *dev, const lm75_os_mode_t v);
 /**
  * @brief Set the value of OS Polarity in the configuration register
  *
- * @param[in] dev pointer to LM75 device descriptior
+ * @param[in] dev pointer to LM75 device descriptor
  * @param[in] v value of OS Polarity
  * @return `ESP_OK` on success
  */
@@ -167,7 +167,7 @@ esp_err_t lm75_set_os_polarity(i2c_dev_t *dev, const lm75_os_polarity_t v);
 
 /**
  * @brief Set the value of OS threshold in the configuration register
- * @param[in] dev pointer to LM75 device descriptior
+ * @param[in] dev pointer to LM75 device descriptor
  * @param[in] value value of OS threshold
  * @return `ESP_OK` on success
  */
@@ -175,14 +175,14 @@ esp_err_t lm75_set_os_threshold(i2c_dev_t *dev, const float value);
 
 /**
  * @brief Shutdown LM75
- * @param[in] dev pointer to LM75 device descriptior
+ * @param[in] dev pointer to LM75 device descriptor
  * @return `ESP_OK` on success
  */
 esp_err_t lm75_shutdown(i2c_dev_t *dev);
 
 /**
  * @brief Wake LM75 up
- * @param[in] dev pointer to LM75 device descriptior
+ * @param[in] dev pointer to LM75 device descriptor
  * @return `ESP_OK` on success
  */
 esp_err_t lm75_wakeup(i2c_dev_t *dev);

--- a/components/max31725/max31725.h
+++ b/components/max31725/max31725.h
@@ -65,7 +65,7 @@ typedef enum {
 } max31725_mode_t;
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  * @param dev Device descriptor
  * @param port I2C port number
  * @param addr I2C address

--- a/components/mcp23008/mcp23008.h
+++ b/components/mcp23008/mcp23008.h
@@ -53,7 +53,7 @@ typedef enum
 } mcp23008_gpio_intr_t;
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  * SCL frequency is 1MHz
  * @param dev Pointer to I2C device descriptor
  * @param port I2C port number

--- a/components/mcp23x17/mcp23x17.h
+++ b/components/mcp23x17/mcp23x17.h
@@ -75,7 +75,7 @@ typedef enum
 #ifdef CONFIG_MCP23X17_IFACE_I2C
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  * SCL frequency is 1MHz
  * @param dev Pointer to device descriptor
  * @param port I2C port number

--- a/components/mcp342x/mcp342x.h
+++ b/components/mcp342x/mcp342x.h
@@ -74,7 +74,7 @@ typedef struct {
 } mcp342x_t;
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  * @param dev Device descriptor
  * @param port I2C port
  * @param addr Device address
@@ -139,9 +139,9 @@ esp_err_t mcp342x_get_data(mcp342x_t *dev, int32_t *data, bool *ready);
 esp_err_t mcp342x_get_voltage(mcp342x_t *dev, float *volts, bool *ready);
 
 /**
- * @brief Do a single converiton
+ * @brief Do a single conversion
  * - start conversion
- * - wait convertion time
+ * - wait conversion time
  * - read conversion result
  *
  * @param dev Device descriptor

--- a/components/mcp4725/mcp4725.h
+++ b/components/mcp4725/mcp4725.h
@@ -43,7 +43,7 @@ typedef enum
 } mcp4725_power_mode_t;
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  * SCL frequency is 1MHz
  * @param dev I2C device descriptor
  * @param port I2C port number

--- a/components/mcp960x/mcp960x.h
+++ b/components/mcp960x/mcp960x.h
@@ -65,7 +65,7 @@ typedef enum {
 } mcp960x_burst_samples_t;
 
 /**
- * Operational mdoe
+ * Operational mode
  */
 typedef enum {
     MCP960X_MODE_NORMAL = 0, /**< default */
@@ -118,7 +118,7 @@ typedef enum {
 } mcp960x_alert_level_t;
 
 /**
- * Alert temperature directon
+ * Alert temperature direction
  */
 typedef enum {
     MCP960X_FALLING = 0, /**< Alert limit for falling or cooling temperatures */

--- a/components/mcp9808/mcp9808.c
+++ b/components/mcp9808/mcp9808.c
@@ -153,14 +153,14 @@ esp_err_t mcp9808_init(i2c_dev_t *dev)
     CHECK(read_reg_16(dev, REG_MANUF, &v));
     if (v != MANUFACTURER_ID)
     {
-        ESP_LOGE(TAG, "Inavlid manufacturer ID 0x%04x", v);
+        ESP_LOGE(TAG, "Invalid manufacturer ID 0x%04x", v);
         return ESP_ERR_INVALID_RESPONSE;
     }
 
     CHECK(read_reg_16(dev, REG_ID, &v));
     if ((v >> 8) != DEVICE_ID)
     {
-        ESP_LOGE(TAG, "Inavlid device ID 0x%02x", v);
+        ESP_LOGE(TAG, "Invalid device ID 0x%02x", v);
         return ESP_ERR_INVALID_RESPONSE;
     }
     ESP_LOGD(TAG, "Device revision: 0x%02x", v & 0xff);

--- a/components/ms5611/ms5611.c
+++ b/components/ms5611/ms5611.c
@@ -1,7 +1,7 @@
 /**
  * @file ms5611.c
  *
- * ESP-IDF driver for barometic pressure sensor MS5611-01BA03
+ * ESP-IDF driver for barometric pressure sensor MS5611-01BA03
  *
  * Ported from esp-open-rtos
  *
@@ -184,14 +184,14 @@ esp_err_t ms5611_get_sensor_data(ms5611_t *dev, int32_t *pressure, float *temper
 
     // dT = D2 - T_ref = D2 - C5 * 2^8
     int32_t dt = raw_temperature - ((int32_t)dev->config_data.t_ref << 8);
-    // Actual temerature (-40...85C with 0.01 resulution)
+    // Actual temperature (-40...85C with 0.01 resolution)
     // TEMP = 20C +dT * TEMPSENSE =2000 + dT * C6 / 2^23
     int64_t temp = (2000 + (int64_t)dt * dev->config_data.tempsens / 8388608);
     // Offset at actual temperature
     // OFF=OFF_t1 + TCO * dT = OFF_t1(C2) * 2^16 + (C4*dT)/2^7
     int64_t off = (int64_t)((int64_t)dev->config_data.off * 65536)
         + (((int64_t)dev->config_data.tco * dt) / 128);
-    // Senisitivity at actual temperature
+    // Sensitivity at actual temperature
     // SENS=SENS_t1 + TCS *dT = SENS_t1(C1) *2^15 + (TCS(C3) *dT)/2^8
     int64_t sens = (int64_t)(((int64_t)dev->config_data.sens) * 32768)
         + (((int64_t)dev->config_data.tcs * dt) / 256);

--- a/components/ms5611/ms5611.h
+++ b/components/ms5611/ms5611.h
@@ -3,7 +3,7 @@
  * @defgroup ms5611 ms5611
  * @{
  *
- * ESP-IDF driver for barometic pressure sensor MS5611-01BA03
+ * ESP-IDF driver for barometric pressure sensor MS5611-01BA03
  *
  * Ported from esp-open-rtos
  *
@@ -46,7 +46,7 @@ typedef struct
     uint16_t sens;       //!< C1 Pressure sensitivity                             | SENS_t1
     uint16_t off;        //!< C2 Pressure offset                                  | OFF_t1
     uint16_t tcs;        //!< C3 Temperature coefficient of pressure sensitivity  | TCS
-    uint16_t tco;        //!< C4 Temperature coefficient of pressuer offset       | TCO
+    uint16_t tco;        //!< C4 Temperature coefficient of pressure offset       | TCO
     uint16_t t_ref;      //!< C5 Reference temperature                            | T_ref
     uint16_t tempsens;   //!< C6 Temperature coefficient of the temperature       | TEMPSENSE
 } ms5611_config_data_t;
@@ -58,11 +58,11 @@ typedef struct
 {
     i2c_dev_t i2c_dev;                //!< I2C device settings
     ms5611_osr_t osr;                 //!< Oversampling setting
-    ms5611_config_data_t config_data; //!< Device configuration, filled upon initalize
+    ms5611_config_data_t config_data; //!< Device configuration, filled upon initialize
 } ms5611_t;
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  * @param dev Device descriptor
  * @param addr I2C address, `MS5611_ADDR_CSB_HIGH` or `MS5611_ADDR_CSB_LOW`
  * @param port I2C port

--- a/components/onewire/onewire.h
+++ b/components/onewire/onewire.h
@@ -71,7 +71,7 @@ bool onewire_reset(gpio_num_t pin);
  * @param[in] pin   The GPIO pin connected to the 1-Wire bus.
  * @param[in] addr  The ROM address of the device to select
  *
- * @return `true` if the "ROM select" command could be succesfully issued,
+ * @return `true` if the "ROM select" command could be successfully issued,
  *         `false` if there was an error.
  */
 bool onewire_select(gpio_num_t pin, const onewire_addr_t addr);
@@ -83,7 +83,7 @@ bool onewire_select(gpio_num_t pin, const onewire_addr_t addr);
  *
  * @param[in] pin   The GPIO pin connected to the 1-Wire bus.
  *
- * @return `true` if the "skip ROM" command could be succesfully issued,
+ * @return `true` if the "skip ROM" command could be successfully issued,
  *         `false` if there was an error.
  */
 bool onewire_skip_rom(gpio_num_t pin);

--- a/components/pca9685/pca9685.c
+++ b/components/pca9685/pca9685.c
@@ -243,7 +243,7 @@ esp_err_t pca9685_set_prescaler(i2c_dev_t *dev, uint8_t prescaler)
 {
     CHECK_ARG(dev);
     CHECK_ARG_LOGE(prescaler >= MIN_PRESCALER,
-            "Inavlid prescaler value: (%d), must be >= 3", prescaler);
+            "Invalid prescaler value: (%d), must be >= 3", prescaler);
 
     CHECK(pca9685_sleep(dev, true));
     I2C_DEV_TAKE_MUTEX(dev);
@@ -272,7 +272,7 @@ esp_err_t pca9685_set_pwm_frequency(i2c_dev_t *dev, uint16_t freq)
 {
     uint32_t prescaler = round_div(INTERNAL_FREQ, (uint32_t)4096 * freq) - 1;
     CHECK_ARG_LOGE(prescaler >= MIN_PRESCALER && prescaler <= MAX_PRESCALER,
-            "Inavlid prescaler value (%d), must be in (%d..%d)", prescaler,
+            "Invalid prescaler value (%d), must be in (%d..%d)", prescaler,
             MIN_PRESCALER, MAX_PRESCALER);
     return pca9685_set_prescaler(dev, prescaler);
 }

--- a/components/pca9685/pca9685.h
+++ b/components/pca9685/pca9685.h
@@ -49,7 +49,7 @@ typedef enum
 } pca9685_channel_t;
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  * @param dev Pointer to I2C device descriptor
  * @param addr PCA9685 address
  * @param port I2C port number

--- a/components/pcf8563/pcf8563.h
+++ b/components/pcf8563/pcf8563.h
@@ -48,10 +48,10 @@ typedef enum {
  * Flags to setup alarm
  */
 typedef enum {
-    PCF8563_ALARM_MATCH_MIN     = 0x01, //!< Alaram when minute matched
-    PCF8563_ALARM_MATCH_HOUR    = 0x02, //!< Alaram when hour matched
-    PCF8563_ALARM_MATCH_DAY     = 0x04, //!< Alaram when day matched
-    PCF8563_ALARM_MATCH_WEEKDAY = 0x08  //!< Alaram when weekday matched
+    PCF8563_ALARM_MATCH_MIN     = 0x01, //!< Alarm when minute matched
+    PCF8563_ALARM_MATCH_HOUR    = 0x02, //!< Alarm when hour matched
+    PCF8563_ALARM_MATCH_DAY     = 0x04, //!< Alarm when day matched
+    PCF8563_ALARM_MATCH_WEEKDAY = 0x08  //!< Alarm when weekday matched
 } pcf8563_alarm_flags_t;
 
 /**
@@ -155,7 +155,7 @@ esp_err_t pcf8563_stop_timer(i2c_dev_t *dev);
 /**
  * @brief Get state of the timer flag
  * @param dev I2C device descriptor
- * @param timer true when flasg is set
+ * @param timer true when flag is set
  * @return `ESP_OK` on success
  */
 esp_err_t pcf8563_get_timer_flag(i2c_dev_t *dev, bool *timer);
@@ -171,7 +171,7 @@ esp_err_t pcf8563_clear_timer_flag(i2c_dev_t *dev);
  * @brief Setup alarm
  * @param dev I2C device descriptor
  * @param int_enable true to enable alarm interrupt
- * @param flags Alaram types, combination of pcf8563_alarm_flags_t values
+ * @param flags Alarm types, combination of pcf8563_alarm_flags_t values
  * @param time Alarm time. Only tm_min, tm_hour, tm_mday and tm_wday are used
  * @return `ESP_OK` on success
  */
@@ -180,7 +180,7 @@ esp_err_t pcf8563_set_alarm(i2c_dev_t *dev, bool int_enable, uint32_t flags, str
 /**
  * @brief Get alarm settings
  * @param dev I2C device descriptor
- * @param[out] int_enabled true if alaram interrupt is enabled
+ * @param[out] int_enabled true if alarm interrupt is enabled
  * @param[out] flags Selected alarm types, combination of pcf8563_alarm_flags_t values
  * @param[out] time Alarm time. Only tm_min, tm_hour, tm_mday and tm_wday are used
  * @return `ESP_OK` on success
@@ -190,7 +190,7 @@ esp_err_t pcf8563_get_alarm(i2c_dev_t *dev, bool *int_enabled, uint32_t *flags, 
 /**
  * @brief Get alarm flag
  * @param dev I2C device descriptor
- * @param[out] alarm true if alarm occured
+ * @param[out] alarm true if alarm occurred
  * @return `ESP_OK` on success
  */
 esp_err_t pcf8563_get_alarm_flag(i2c_dev_t *dev, bool *alarm);

--- a/components/pcf8574/pcf8574.c
+++ b/components/pcf8574/pcf8574.c
@@ -1,7 +1,7 @@
 /**
  * @file pcf8574.c
  *
- * ESP-IDF driver for PCF8574 compartible remote 8-bit I/O expanders for I2C-bus
+ * ESP-IDF driver for PCF8574 compatible remote 8-bit I/O expanders for I2C-bus
  *
  * Copyright (C) 2018 Ruslan V. Uss <https://github.com/UncleRus>
  *

--- a/components/pcf8574/pcf8574.h
+++ b/components/pcf8574/pcf8574.h
@@ -3,7 +3,7 @@
  * @defgroup pcf8574 pcf8574
  * @{
  *
- * ESP-IDF driver for PCF8574 compartible remote 8-bit I/O expanders for I2C-bus
+ * ESP-IDF driver for PCF8574 compatible remote 8-bit I/O expanders for I2C-bus
  *
  * Copyright (C) 2018 Ruslan V. Uss <https://github.com/UncleRus>
  *
@@ -21,7 +21,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  * SCL frequency is 100kHz
  * @param dev Pointer to I2C device descriptor
  * @param port I2C port number

--- a/components/pcf8575/pcf8575.h
+++ b/components/pcf8575/pcf8575.h
@@ -23,7 +23,7 @@ extern "C" {
 #define PCF8575_I2C_ADDR_BASE 0x20
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  *
  * SCL frequency is 400kHz
  *

--- a/components/pcf8591/pcf8591.h
+++ b/components/pcf8591/pcf8591.h
@@ -31,12 +31,12 @@ extern "C" {
 typedef enum {
     PCF8591_IC_4_SINGLES = 0,   //!< Four single-ended inputs
     PCF8591_IC_DIFF,            //!< Three differential inputs
-    PCF8591_IC_2_SINGLES_DIFF,  //!< Two single-ended and differnetial mixed
+    PCF8591_IC_2_SINGLES_DIFF,  //!< Two single-ended and differential mixed
     PCF8591_IC_2_DIFFS          //!< Two differential inputs
 } pcf8591_input_conf_t;
 
 /**
- * Initialize device descriptior
+ * Initialize device descriptor
  * @param dev Device descriptor
  * @param addr I2C device address
  * @param port I2C port number

--- a/components/qmc5883l/qmc5883l.h
+++ b/components/qmc5883l/qmc5883l.h
@@ -92,7 +92,7 @@ typedef struct {
 } qmc5883l_t;
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  * @param dev Device descriptor
  * @param port I2C port number
  * @param addr I2C address

--- a/components/rda5807m/rda5807m.h
+++ b/components/rda5807m/rda5807m.h
@@ -275,7 +275,7 @@ esp_err_t rda5807m_set_afc(rda5807m_t *dev, bool afc);
  * @param up Seeking direction: true - up, false - down
  * @param wrap If true, wrap at the upper or lower band limit and
  *             continue seeking, else stop seeking at bounds
- * @param threshold Seeking SNR treshold, 0..`RDA5807M_SEEK_TH_MAX`.
+ * @param threshold Seeking SNR threshold, 0..`RDA5807M_SEEK_TH_MAX`.
  *                  Usually it's `RDA5807M_SEEK_TH_DEF`
  * @return `ESP_OK` on success
  */

--- a/components/sht3x/sht3x.c
+++ b/components/sht3x/sht3x.c
@@ -34,7 +34,7 @@ static const uint16_t SHT3X_MEASURE_CMD[6][3] = {
         {0x2032, 0x2024, 0x202f}, // [PERIODIC_05][H,M,L]
         {0x2130, 0x2126, 0x212d}, // [PERIODIC_1 ][H,M,L]
         {0x2236, 0x2220, 0x222b}, // [PERIODIC_2 ][H,M,L]
-        {0x2234, 0x2322, 0x2329}, // [PERIODIC_4 ][H,M,L]
+        {0x2334, 0x2322, 0x2329}, // [PERIODIC_4 ][H,M,L]
         {0x2737, 0x2721, 0x272a}  // [PERIODIC_10][H,M,L]
 };
 

--- a/components/sht3x/sht3x.c
+++ b/components/sht3x/sht3x.c
@@ -26,6 +26,7 @@ const char *TAG = "SHT3x";
 #define SHT3X_CLEAR_STATUS_CMD         0x3041
 #define SHT3X_RESET_CMD                0x30A2
 #define SHT3X_FETCH_DATA_CMD           0xE000
+#define SHT3X_STOP_PERIODIC_MEAS_CMD   0x3093
 #define SHT3X_HEATER_ON_CMD            0x306D
 #define SHT3X_HEATER_OFF_CMD           0x3066
 
@@ -259,6 +260,19 @@ esp_err_t sht3x_start_measurement(sht3x_t *dev, sht3x_mode_t mode, sht3x_repeat_
     I2C_DEV_TAKE_MUTEX(&dev->i2c_dev);
     I2C_DEV_CHECK(&dev->i2c_dev, start_nolock(dev, mode, repeat));
     I2C_DEV_GIVE_MUTEX(&dev->i2c_dev);
+
+    return ESP_OK;
+}
+
+esp_err_t sht3x_stop_periodic_measurement(sht3x_t *dev)
+{
+    CHECK_ARG(dev);
+
+    CHECK(send_cmd(dev, SHT3X_STOP_PERIODIC_MEAS_CMD));
+    dev->mode = SHT3X_SINGLE_SHOT;
+    dev->meas_start_time = 0;
+    dev->meas_started = false;
+    dev->meas_first = false;
 
     return ESP_OK;
 }

--- a/components/sht3x/sht3x.c
+++ b/components/sht3x/sht3x.c
@@ -257,7 +257,7 @@ esp_err_t sht3x_start_measurement(sht3x_t *dev, sht3x_mode_t mode, sht3x_repeat_
     CHECK_ARG(dev);
 
     I2C_DEV_TAKE_MUTEX(&dev->i2c_dev);
-    I2C_DEV_CHECK(&dev->i2c_dev, start_nolock(dev, SHT3X_SINGLE_SHOT, SHT3X_HIGH));
+    I2C_DEV_CHECK(&dev->i2c_dev, start_nolock(dev, mode, repeat));
     I2C_DEV_GIVE_MUTEX(&dev->i2c_dev);
 
     return ESP_OK;

--- a/components/sht3x/sht3x.h
+++ b/components/sht3x/sht3x.h
@@ -175,6 +175,17 @@ uint8_t sht3x_get_measurement_duration(sht3x_repeat_t repeat);
 esp_err_t sht3x_start_measurement(sht3x_t *dev, sht3x_mode_t mode, sht3x_repeat_t repeat);
 
 /**
+ * @brief Stop the periodic mode measurements
+ *
+ * The function stops the measurements  in *periodic mode*
+ * (periodic measurements) and the sensor returns in *single shot mode*
+ *
+ * @param dev       Device descriptor
+ * @return          `ESP_OK` on success
+ */
+esp_err_t sht3x_stop_periodic_measurement(sht3x_t *dev);
+
+/**
  * @brief Read measurement results from sensor as raw data
  *
  * The function read measurement results from the sensor, checks the CRC

--- a/components/sht3x/sht3x.h
+++ b/components/sht3x/sht3x.h
@@ -69,7 +69,7 @@ typedef struct
 } sht3x_t;
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  *
  * @param dev       Device descriptor
  * @param port      I2C port
@@ -139,7 +139,7 @@ esp_err_t sht3x_measure(sht3x_t *dev, float *temperature, float *humidity);
  * the measurement results can be fetched.
  *
  * Please note: The duration only depends on repeatability level. Therefore,
- * it can be considered as constant for a repeatibility.
+ * it can be considered as constant for a repeatability.
  *
  * @param repeat    Repeatability, see type *sht3x_repeat_t*
  * @return          Measurement duration given in RTOS ticks
@@ -151,7 +151,7 @@ uint8_t sht3x_get_measurement_duration(sht3x_repeat_t repeat);
  *
  * The function starts the measurement either in *single shot mode*
  * (exactly one measurement) or *periodic mode* (periodic measurements)
- * with given repeatabilty.
+ * with given repeatability.
  *
  * In the *single shot mode*, this function has to be called for each
  * measurement. The measurement duration has to be waited every time

--- a/components/si7021/si7021.h
+++ b/components/si7021/si7021.h
@@ -47,7 +47,7 @@ typedef enum {
 } si7021_resolution_t;
 
 /**
- * Initialize device descriptior
+ * Initialize device descriptor
  * @param dev Device descriptor
  * @param port I2C port
  * @param sda_gpio SDA GPIO pin

--- a/components/tca9548/tca9548.h
+++ b/components/tca9548/tca9548.h
@@ -43,7 +43,7 @@ extern "C" {
 #define TCA9548_CHANNEL7 BV(7)
 
 /**
- * Initialize device descriptior
+ * Initialize device descriptor
  * @param dev Device descriptor
  * @param port I2C port
  * @param addr Device address

--- a/components/tca95x5/tca95x5.h
+++ b/components/tca95x5/tca95x5.h
@@ -23,7 +23,7 @@ extern "C" {
 #define TCA95X5_I2C_ADDR_BASE 0x20
 
 /**
- * @brief Initialize device descriptior
+ * @brief Initialize device descriptor
  *
  * SCL frequency is 400kHz
  *

--- a/components/tda74xx/tda74xx.h
+++ b/components/tda74xx/tda74xx.h
@@ -126,7 +126,7 @@ esp_err_t tda74xx_get_volume(i2c_dev_t *dev, int8_t *volume_db);
 esp_err_t tda74xx_set_equalizer_gain(i2c_dev_t *dev, tda74xx_band_t band, int8_t gain_db);
 
 /**
- * Get equlizer gain
+ * Get equalizer gain
  * @param dev Device descriptor
  * @param band Band
  * @param[out] gain_db Gain, -14..14 dB in 2 dB step

--- a/components/tsl2561/tsl2561.h
+++ b/components/tsl2561/tsl2561.h
@@ -64,7 +64,7 @@ typedef struct
 } tsl2561_t;
 
 /**
- * Initialize device descriptior
+ * Initialize device descriptor
  * @param dev Device descriptor
  * @param addr I2C device address, `TSL2561_I2C_ADDR_...` const
  * @param port I2C port

--- a/components/tsl2591/tsl2591.c
+++ b/components/tsl2591/tsl2591.c
@@ -22,14 +22,14 @@ static const char *TAG = "TSL2591";
 #define TSL2591_REG_COMMAND 0x80
 #define TSL2591_REG_ENABLE  0x00
 #define TSL2591_REG_CONTROL 0x01
-#define TSL2591_REG_AILTL   0x04    // ALS interrupt low treshold low byte
-#define TSL2591_REG_AILTH   0x05    // ALS interrupt low treshold high byte
-#define TSL2591_REG_AIHTL   0x06    // ALS interrupt high treshold low byte
-#define TSL2591_REG_AIHTH   0x07    // ALS interrupt high treshold high byte
-#define TSL2591_REG_NPAILTL 0x08    // No ALS persist interrupt low treshold low byte
-#define TSL2591_REG_NPAILTH 0x09    // No ALS persist interrupt low treshold high byte
-#define TSL2591_REG_NPAIHTL 0x0A    // No ALS persist interrupt high treshold low byte
-#define TSL2591_REG_NPAIHTH 0x0B    // No ALS persist interrupt high treshold high byte
+#define TSL2591_REG_AILTL   0x04    // ALS interrupt low threshold low byte
+#define TSL2591_REG_AILTH   0x05    // ALS interrupt low threshold high byte
+#define TSL2591_REG_AIHTL   0x06    // ALS interrupt high threshold low byte
+#define TSL2591_REG_AIHTH   0x07    // ALS interrupt high threshold high byte
+#define TSL2591_REG_NPAILTL 0x08    // No ALS persist interrupt low threshold low byte
+#define TSL2591_REG_NPAILTH 0x09    // No ALS persist interrupt low threshold high byte
+#define TSL2591_REG_NPAIHTL 0x0A    // No ALS persist interrupt high threshold low byte
+#define TSL2591_REG_NPAIHTH 0x0B    // No ALS persist interrupt high threshold high byte
 #define TSL2591_REG_PERSIST 0x0C    // Interrupt persistence filter
 #define TSL2591_REG_C0DATAL 0x14
 #define TSL2591_REG_C0DATAH 0x15
@@ -45,7 +45,7 @@ static const char *TAG = "TSL2591";
 #define TSL2591_SPECIAL_SET_INTR        0x04    // Forces interrupt
 #define TSL2591_SPECIAL_CLEAR_INTR      0x06    // Clear ALS interrupt
 #define TSL2591_SPECIAL_CLEAR_BOTH      0x07    // Clear ALS and no persist ALS interrupt
-#define TSL2591_SEPCIAL_CLEAR_NP_INTR   0x0A    // Clear no persist ALS interrupt
+#define TSL2591_SPECIAL_CLEAR_NP_INTR   0x0A    // Clear no persist ALS interrupt
 
 // TSL2591 integration times in useconds.
 #define TSL2591_INTEGRATION_TIME_100MS  110
@@ -559,7 +559,7 @@ esp_err_t tsl2591_clear_als_np_intr(tsl2591_t *dev)
     I2C_DEV_TAKE_MUTEX(&dev->i2c_dev);
 
     I2C_DEV_CHECK(&dev->i2c_dev,
-        write_special_function(dev, TSL2591_SEPCIAL_CLEAR_NP_INTR));
+        write_special_function(dev, TSL2591_SPECIAL_CLEAR_NP_INTR));
 
     I2C_DEV_GIVE_MUTEX(&dev->i2c_dev);
 

--- a/components/tsl4531/tsl4531.h
+++ b/components/tsl4531/tsl4531.h
@@ -58,7 +58,7 @@ typedef struct {
 } tsl4531_t;
 
 /**
- * Initialize device descriptior
+ * Initialize device descriptor
  * @param dev Device descriptor
  * @param port I2C port
  * @param sda_gpio SDA GPIO pin
@@ -86,7 +86,7 @@ esp_err_t tsl4531_init(tsl4531_t *dev);
  * @param dev Device descriptor
  * @param integration_time Integration time
  * @param skip_power_save PowerSave Mode. When true, the power save states are
- *        skipped following a light integration cyclefor shorter sampling rates
+ *        skipped following a light integration cycle for shorter sampling rates
  * @return `ESP_OK` on success
  */
 esp_err_t tsl4531_config(tsl4531_t *dev, tsl4531_integration_time_t integration_time, bool skip_power_save);

--- a/components/tsys01/tsys01.h
+++ b/components/tsys01/tsys01.h
@@ -90,7 +90,7 @@ esp_err_t tsys01_start(tsys01_t *dev);
 esp_err_t tsys01_get_temp(tsys01_t *dev, uint32_t *raw, float *t);
 
 /**
- * @brief Perform temperature convertion
+ * @brief Perform temperature conversion
  *
  * This function starts temperature conversion,
  * waits 10 ms and reads result.

--- a/components/ultrasonic/ultrasonic.h
+++ b/components/ultrasonic/ultrasonic.h
@@ -45,7 +45,7 @@ esp_err_t ultrasonic_init(const ultrasonic_sensor_t *dev);
  * Measure distance
  * @param dev Pointer to the device descriptor
  * @param max_distance Maximal distance to measure, centimeters
- * @param distance Distance in centimeters or ULTRASONIC_ERROR_xxx if error occured
+ * @param distance Distance in centimeters or ULTRASONIC_ERROR_xxx if error occurred
  * @return `ESP_OK` on success
  */
 esp_err_t ultrasonic_measure_cm(const ultrasonic_sensor_t *dev, uint32_t max_distance, uint32_t *distance);

--- a/examples/ads1115/main/main.c
+++ b/examples/ads1115/main/main.c
@@ -56,7 +56,7 @@ static void measure(size_t n)
 }
 
 // Main task
-void ads111x_test(void *pvParamters)
+void ads111x_test(void *pvParameters)
 {
     gain_val = ads111x_gain_values[GAIN];
 
@@ -65,7 +65,7 @@ void ads111x_test(void *pvParamters)
     {
         ESP_ERROR_CHECK(ads111x_init_desc(&devices[i], addr[i], I2C_PORT, SDA_GPIO, SCL_GPIO));
 
-        ESP_ERROR_CHECK(ads111x_set_mode(&devices[i], ADS111X_MODE_CONTINUOS));    // Continuous conversion mode
+        ESP_ERROR_CHECK(ads111x_set_mode(&devices[i], ADS111X_MODE_CONTINUOUS));    // Continuous conversion mode
         ESP_ERROR_CHECK(ads111x_set_data_rate(&devices[i], ADS111X_DATA_RATE_32)); // 32 samples per second
         ESP_ERROR_CHECK(ads111x_set_input_mux(&devices[i], ADS111X_MUX_0_GND));    // positive = AIN0, negative = GND
         ESP_ERROR_CHECK(ads111x_set_gain(&devices[i], GAIN));

--- a/examples/bh1750/main/main.c
+++ b/examples/bh1750/main/main.c
@@ -24,7 +24,7 @@ void test(void *pvParameters)
     memset(&dev, 0, sizeof(i2c_dev_t)); // Zero descriptor
 
     ESP_ERROR_CHECK(bh1750_init_desc(&dev, ADDR, 0, SDA_GPIO, SCL_GPIO));
-    ESP_ERROR_CHECK(bh1750_setup(&dev, BH1750_MODE_CONTINIOUS, BH1750_RES_HIGH));
+    ESP_ERROR_CHECK(bh1750_setup(&dev, BH1750_MODE_CONTINUOUS, BH1750_RES_HIGH));
 
     while (1)
     {

--- a/examples/bme680/main/main.c
+++ b/examples/bme680/main/main.c
@@ -14,7 +14,7 @@
 #define APP_CPU_NUM PRO_CPU_NUM
 #endif
 
-void bme680_test(void *pvParamters)
+void bme680_test(void *pvParameters)
 {
     bme680_t sensor;
     memset(&sensor, 0, sizeof(bme680_t));
@@ -31,7 +31,7 @@ void bme680_test(void *pvParamters)
     // Change the IIR filter size for temperature and pressure to 7.
     bme680_set_filter_size(&sensor, BME680_IIR_SIZE_7);
 
-    // Change the heater profile 0 to 200 degree Celcius for 100 ms.
+    // Change the heater profile 0 to 200 degree Celsius for 100 ms.
     bme680_set_heater_profile(&sensor, 0, 200, 100);
     bme680_use_heater_profile(&sensor, 0);
 

--- a/examples/bmp280/main/main.c
+++ b/examples/bmp280/main/main.c
@@ -17,7 +17,7 @@
 #define APP_CPU_NUM PRO_CPU_NUM
 #endif
 
-void bmp280_test(void *pvParamters)
+void bmp280_test(void *pvParameters)
 {
     bmp280_params_t params;
     bmp280_init_default_params(&params);

--- a/examples/lm75/main/main.c
+++ b/examples/lm75/main/main.c
@@ -37,7 +37,7 @@
 
 static const char *TAG = "lm75_example";
 
-void lm75_task(void *pvParamters)
+void lm75_task(void *pvParameters)
 {
     uint8_t v;
     int shutdown = 0;
@@ -88,21 +88,21 @@ void lm75_task(void *pvParamters)
     ESP_LOGI(TAG, "Read Overtemperature Shutdown temperature");
     ESP_ERROR_CHECK(lm75_get_os_threshold(&dev, &os_temperature_in_reg));
     if (os_temperature_in_reg != os_temperature) {
-        ESP_LOGE(TAG, "invalid OS temperature fonud: %.3f", os_temperature_in_reg);
+        ESP_LOGE(TAG, "invalid OS temperature found: %.3f", os_temperature_in_reg);
     }
 
-    ESP_LOGI(TAG, "Set OS polarlity to LM75_OSP_HIGH");
+    ESP_LOGI(TAG, "Set OS polarity to LM75_OSP_HIGH");
     ESP_ERROR_CHECK(lm75_set_os_polarity(&dev, LM75_OSP_HIGH));
     ESP_ERROR_CHECK(lm75_get_os_polarity(&dev, &v));
     if (v != LM75_OSP_HIGH) {
-        ESP_LOGE(TAG, "polarlity is not LM75_OSP_HIGH");
+        ESP_LOGE(TAG, "polarity is not LM75_OSP_HIGH");
     }
 
-    ESP_LOGI(TAG, "Set OS polarlity to LM75_OSP_LOW");
+    ESP_LOGI(TAG, "Set OS polarity to LM75_OSP_LOW");
     ESP_ERROR_CHECK(lm75_set_os_polarity(&dev, LM75_OSP_LOW));
     ESP_ERROR_CHECK(lm75_get_os_polarity(&dev, &v));
     if (v != LM75_OSP_LOW) {
-        ESP_LOGE(TAG, "polarlity is not LM75_OSP_LOW");
+        ESP_LOGE(TAG, "polarity is not LM75_OSP_LOW");
     }
 
     ESP_LOGI(TAG, "Starting the loop");

--- a/examples/max31725/main/main.c
+++ b/examples/max31725/main/main.c
@@ -24,7 +24,7 @@
 #define FORMAT MAX31725_FMT_NORMAL
 
 // Main task
-void test(void *pvParamters)
+void test(void *pvParameters)
 {
     i2c_dev_t dev;
     memset(&dev, 0, sizeof(i2c_dev_t));

--- a/examples/mcp23017/main/main.c
+++ b/examples/mcp23017/main/main.c
@@ -35,7 +35,7 @@ void test(void *pvParameters)
 
     // Setup PORTB0 as output
     mcp23x17_set_mode(&dev, 8, MCP23X17_GPIO_OUTPUT);
-    // do some blinkning
+    // do some blinking
     bool on = true;
     while (1)
     {

--- a/examples/mcp23s17/main/main.c
+++ b/examples/mcp23s17/main/main.c
@@ -48,7 +48,7 @@ void test(void *pvParameters)
 
     // Setup PORTB0 as output
     mcp23x17_set_mode(&dev, 8, MCP23X17_GPIO_OUTPUT);
-    // do some blinkning
+    // do some blinking
     bool on = true;
     while (1)
     {

--- a/examples/mcp4725/main/main.c
+++ b/examples/mcp4725/main/main.c
@@ -44,7 +44,7 @@ void task(void *pvParameters)
         wait_for_eeprom(&dev);
     }
 
-    printf("Set default DAC ouptut value to MAX...\n");
+    printf("Set default DAC output value to MAX...\n");
     ESP_ERROR_CHECK(mcp4725_set_raw_output(&dev, MCP4725_MAX_VALUE, true));
     wait_for_eeprom(&dev);
 

--- a/examples/mcp9808/main/main.c
+++ b/examples/mcp9808/main/main.c
@@ -25,7 +25,7 @@
 
 #define ADDR MCP9808_I2C_ADDR_000
 
-void task(void *pvParamters)
+void task(void *pvParameters)
 {
     float temperature;
     esp_err_t res;

--- a/examples/ms5611_i2c/main/main.c
+++ b/examples/ms5611_i2c/main/main.c
@@ -20,7 +20,7 @@
 
 #define OVERSAMPLING_RATIO MS5611_OSR_1024
 
-void ms5611_test(void *pvParamters)
+void ms5611_test(void *pvParameters)
 {
     ms5611_t dev;
     memset(&dev, 0, sizeof(ms5611_t));

--- a/examples/pca9685/main/main.c
+++ b/examples/pca9685/main/main.c
@@ -17,7 +17,7 @@
 #define APP_CPU_NUM PRO_CPU_NUM
 #endif
 
-void pca9685_test(void *pvParamters)
+void pca9685_test(void *pvParameters)
 {
     i2c_dev_t dev;
     memset(&dev, 0, sizeof(i2c_dev_t));

--- a/examples/pcf8591/main/main.c
+++ b/examples/pcf8591/main/main.c
@@ -17,7 +17,7 @@
 #define APP_CPU_NUM PRO_CPU_NUM
 #endif
 
-void pcf8591_test(void *pvParamters)
+void pcf8591_test(void *pvParameters)
 {
     i2c_dev_t dev;
     memset(&dev, 0, sizeof(i2c_dev_t));

--- a/examples/sht3x/main/main.c
+++ b/examples/sht3x/main/main.c
@@ -5,7 +5,7 @@
  * *periodic mode*. In *single shot* mode either low level or high level
  * functions are used.
  *
- * Harware configuration:
+ * Hardware configuration:
  *
  *    +-----------------+     +----------+
  *    |     ESP32 |     | SHT3x    |
@@ -50,7 +50,7 @@ static sht3x_t dev;
  * efficiency reasons it uses *single shot* mode. In this example it uses the
  * high level function *sht3x_measure* to perform one measurement in each cycle.
  */
-void task(void *pvParamters)
+void task(void *pvParameters)
 {
     float temperature;
     float humidity;
@@ -76,7 +76,7 @@ void task(void *pvParamters)
  * measurement, waits for the results and fetches the results using separate
  * functions
  */
-void task(void *pvParamters)
+void task(void *pvParameters)
 {
     float temperature;
     float humidity;
@@ -110,7 +110,7 @@ void task(void *pvParamters)
  * seconds. It starts the SHT3x in periodic mode with 1 measurements per
  * second (*SHT3X_PERIODIC_1MPS*).
  */
-void task(void *pvParamters)
+void task(void *pvParameters)
 {
     float temperature;
     float humidity;

--- a/examples/si7021/main/main.c
+++ b/examples/si7021/main/main.c
@@ -18,7 +18,7 @@
 #define APP_CPU_NUM PRO_CPU_NUM
 #endif
 
-void task(void *pvParamters)
+void task(void *pvParameters)
 {
     i2c_dev_t dev;
     memset(&dev, 0, sizeof(i2c_dev_t));

--- a/examples/tsl2561/main/main.c
+++ b/examples/tsl2561/main/main.c
@@ -19,7 +19,7 @@
 
 #define ADDR TSL2561_I2C_ADDR_FLOAT
 
-void tsl2561_test(void *pvParamters)
+void tsl2561_test(void *pvParameters)
 {
     tsl2561_t dev;
     memset(&dev, 0, sizeof(tsl2561_t));

--- a/examples/tsl2591_interrupt/main/main.c
+++ b/examples/tsl2591_interrupt/main/main.c
@@ -32,7 +32,7 @@ static xQueueHandle isr_evt_queue = NULL;
 
 static void IRAM_ATTR isr_handler(void *arg)
 {
-    // Be carfull to pass a address to a  pointer.
+    // Be careful to pass a address to a  pointer.
     xQueueSendFromISR(isr_evt_queue, &arg, NULL);
 }
 
@@ -75,10 +75,10 @@ static void isr_task(void *arg)
     }
 }
 
-void tsl2591_task(void *pvParamters)
+void tsl2591_task(void *pvParameters)
 {
     ESP_LOGI(TAG, "tsl2591 task started.");
-    tsl2591_t *dev = (tsl2591_t*) pvParamters;
+    tsl2591_t *dev = (tsl2591_t*) pvParameters;
     uint16_t channel0, channel1;
     float lux;
 
@@ -100,7 +100,7 @@ void app_main()
     // i2cdev initialisation
     ESP_ERROR_CHECK(i2cdev_init());
 
-    // tsl2591 intialisation
+    // tsl2591 initialisation
     tsl2591_t* dev = malloc(sizeof(tsl2591_t));
     memset(dev, 0, sizeof(tsl2591_t));
 

--- a/examples/tsl2591_simple/main/main.c
+++ b/examples/tsl2591_simple/main/main.c
@@ -17,7 +17,7 @@
 #define APP_CPU_NUM PRO_CPU_NUM
 #endif
 
-void tsl2591_test(void *pvParamters)
+void tsl2591_test(void *pvParameters)
 {
     tsl2591_t dev;
     memset(&dev, 0, sizeof(tsl2591_t));

--- a/examples/tsl4531/main/main.c
+++ b/examples/tsl4531/main/main.c
@@ -17,7 +17,7 @@
 #define APP_CPU_NUM PRO_CPU_NUM
 #endif
 
-void tsl4531_test(void *pvParamters)
+void tsl4531_test(void *pvParameters)
 {
     tsl4531_t dev;
     memset(&dev, 0, sizeof(tsl4531_t));

--- a/examples/ultrasonic/main/main.c
+++ b/examples/ultrasonic/main/main.c
@@ -8,7 +8,7 @@
 #define TRIGGER_GPIO 17
 #define ECHO_GPIO 16
 
-void ultrasonic_test(void *pvParamters)
+void ultrasonic_test(void *pvParameters)
 {
     ultrasonic_sensor_t sensor = {
         .trigger_pin = TRIGGER_GPIO,


### PR DESCRIPTION
- Typographic corrections across components and examples
- SHT3x component : the sht3x_start_measurement function was not using the given parameters
- SHT3x component : correct command for periodic measurements at 4mps with high reliability
- SHT3x component  : add command and function to stop periodic measurements