### PR TITLE
ci: implement markdownlint

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,16 +9,19 @@ assignees: ''
 
 <!-- Please erase any parts of this template not applicable to your Issue. -->
 
-**Device type**
+**Device type**:
+
 - [x] ESP32
 - [x] ESP8226
 
-**Framework version**
+**Framework version**:
+
 - [x] ESP-IDF latest master
 - [x] ESP-IDF 3.2.x
 - [x] ESP-IDF 3.3.x
 - [x] ESP8266 RTOS SDK latest master
 - [x] ESP8266 RTOS SDK 3.2
 
-**Describe the bug**
+**Describe the bug**:
+
 A clear and concise description of what the bug is.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,3 +76,21 @@ jobs:
             git diff --color
             exit 1
           fi
+  mdl:
+    runs-on: ubuntu-latest
+    needs: pre_build
+    if: ${{ needs.pre_build.outputs.should_skip != 'true' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+          bundler-cache: true
+
+      - name: Run Markdown lint tool
+        run: |
+          bundle exec mdl -g .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,4 +93,18 @@ jobs:
 
       - name: Run Markdown lint tool
         run: |
-          bundle exec mdl -g .
+          # XXX check known files and directory instead of all files.
+          #
+          # this workaround is necessary because of several issues:
+          #
+          # * `mdl` does not support `ignore files or directories`.
+          # * `mdl` does not support inline ignore
+          # * `FAQ.md` has headings whose texts are too long
+          #
+          # relates issues:
+          #
+          # * https://github.com/markdownlint/markdownlint/issues/167
+          # * https://github.com/markdownlint/markdownlint/issues/16
+          #
+          # bundle exec mdl -i -g .
+          bundle exec mdl -i README.md CHANGELOG.md components examples

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,3 @@
+# configuration file for `mdl` command line options
+
+style "#{File.dirname(__FILE__)}/.mdlstyle.rb"

--- a/.mdlstyle.rb
+++ b/.mdlstyle.rb
@@ -6,3 +6,5 @@ all
 rule "MD003", style: :atx
 rule "MD007", indent: 4
 rule "MD013", code_blocks: false, tables: false
+rule "MD024", allow_different_nesting: true
+rule "MD029", style: :ordered

--- a/.mdlstyle.rb
+++ b/.mdlstyle.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# our markdown style
+
+all
+rule "MD003", style: :atx
+rule "MD007", indent: 4
+rule "MD013", code_blocks: false, tables: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,117 @@
+# The behavior of RuboCop can be controlled via the .rubocop.yml
+# configuration file. It makes it possible to enable/disable
+# certain cops (checks) and to alter their behavior if they accept
+# any parameters. The file can be placed either in your home
+# directory or in some project directory.
+#
+# RuboCop will start looking for the configuration file in the directory
+# where the inspected file is and continue its way up to the root directory.
+#
+# See https://docs.rubocop.org/rubocop/configuration
+
+AllCops:
+  Exclude:
+    # there is no reason to test external files
+    - "vendor/**/*"
+  # enable detailed explanations available in cops
+  # the default output is not enough to understand what is wrong
+  DisplayCopNames: true
+  ExtraDetails: true
+  DisplayStyleGuide: true
+
+  # the default CacheRootDirectory is no longer `/tmp`, but a directory under
+  # `$HOME` and some Unix platforms use symlink to that path
+  AllowSymlinksInCacheRootDirectory: true
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/SymbolArray:
+  # perefer brackets for `grep-ability`
+  EnforcedStyle: brackets
+
+Metrics/BlockLength:
+  Exclude:
+  IgnoredMethods:
+    # these two exclude long blocks in `_spec.rb`
+    - describe
+    - context
+
+Layout/LineLength:
+  Exclude:
+    # `_spec.rb` often contains one-liner shell command
+    - "**/*_spec.rb"
+    # Gemfile is not application code
+    - "Gemfile"
+  # ignore heredoc for readability
+  AllowHeredoc: true
+  # URLs are almost always long
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
+    - git
+    - ftp
+  IgnoreCopDirectives: true
+
+# New cops
+Gemspec/DateAssignment: # (new in 1.10)
+  Enabled: true
+Layout/SpaceBeforeBrackets: # (new in 1.7)
+  Enabled: true
+Lint/AmbiguousAssignment: # (new in 1.7)
+  Enabled: true
+Lint/DeprecatedConstants: # (new in 1.8)
+  Enabled: true
+Lint/DuplicateBranch: # (new in 1.3)
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
+  Enabled: true
+Lint/EmptyBlock: # (new in 1.1)
+  Enabled: true
+Lint/EmptyClass: # (new in 1.3)
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
+  Enabled: true
+Lint/NumberedParameterAssignment: # (new in 1.9)
+  Enabled: true
+Lint/OrAssignmentToConstant: # (new in 1.9)
+  Enabled: true
+Lint/RedundantDirGlobSort: # (new in 1.8)
+  Enabled: true
+Lint/SymbolConversion: # (new in 1.9)
+  Enabled: true
+Lint/ToEnumArguments: # (new in 1.1)
+  Enabled: true
+Lint/TripleQuotes: # (new in 1.9)
+  Enabled: true
+Lint/UnexpectedBlockArity: # (new in 1.5)
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
+  Enabled: true
+Style/ArgumentsForwarding: # (new in 1.1)
+  Enabled: true
+Style/CollectionCompact: # (new in 1.2)
+  Enabled: true
+Style/DocumentDynamicEvalDefinition: # (new in 1.1)
+  Enabled: true
+Style/EndlessMethod: # (new in 1.8)
+  Enabled: true
+Style/HashConversion: # (new in 1.10)
+  Enabled: true
+Style/HashExcept: # (new in 1.7)
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # (new in 1.9)
+  Enabled: true
+Style/NegatedIfElseCondition: # (new in 1.2)
+  Enabled: true
+Style/NilLambda: # (new in 1.3)
+  Enabled: true
+Style/RedundantArgument: # (new in 1.4)
+  Enabled: true
+Style/StringChars: # (new in 1.12)
+  Enabled: true
+Style/SwapValues: # (new in 1.1)
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Features
 
 - (wiegand) Wiegand protocol receiver
-- (lib8tion) Math functions specifically designed for LED programming (port from FastLED)
+- (lib8tion) Math functions specifically designed for LED programming (port
+  from FastLED)
 - (color) Common library for RGB and HSV colors (port from FastLED)
 - (noise) Noise generation functions (port from FastLED)
 - (framebuffer) RGB framebuffer and animation component
@@ -106,7 +107,7 @@
 
 - (ds1307) #110 wrong squarewave frequency returned
 - (sht3x, hmc5883l, hx711) #118 SHT3x measurements fail after 72min
-- (pca9685) d4f5e35 Fix full on/off 
+- (pca9685) d4f5e35 Fix full on/off
 - (ina219) Typo fix
 
 ## v.0.5-beta

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # How to contribute to `esp-idf-lib`
 
 ## Table of Contents
+
 <!-- vim-markdown-toc GFM -->
 
 * [Possible contributions](#possible-contributions)
@@ -13,7 +14,8 @@
 * [Development Life Cycle](#development-life-cycle)
     * [Creating an Issue](#creating-an-issue)
     * [Creating a feature branch in your fork and develop](#creating-a-feature-branch-in-your-fork-and-develop)
-    * [Code style](#code-style)
+    * [C Code style](#c-code-style)
+    * [`markdown` Code style](#markdown-code-style)
     * [Typical issues you will face in developments](#typical-issues-you-will-face-in-developments)
     * [Writing a commit message](#writing-a-commit-message)
     * [Creating a Pull Request](#creating-a-pull-request)
@@ -49,24 +51,24 @@ expected in a different environment.
 Please include how to reproduce the bug in the Issue. The more context, the
 better. For example:
 
-- The _full_ error message in text format and the entire code (comment with
+* The _full_ error message in text format and the entire code (comment with
   ` ``` ` for short code, use [Gist](https://gist.github.com) for long code)
-- The circuit diagram
-- Captured signals by an oscilloscope or a signal analyser ([sigrok](https://sigrok.org/))
+* The circuit diagram
+* Captured signals by an oscilloscope or a signal analyser ([sigrok](https://sigrok.org/))
 
 A question as a bug report is okay but we expect bug reporters to do their
 homework. The homework include:
 
-- Reading the data sheets
-- Reading [the official documentation of `esp-idf`](https://docs.espressif.com/projects/esp-idf)
+* Reading the data sheets
+* Reading [the official documentation of `esp-idf`](https://docs.espressif.com/projects/esp-idf)
   (it's good, really)
-- Understanding C language in general
+* Understanding C language in general
 
 For introductory C tutorials, see:
 
-- [C Tutorial](https://www.tutorialspoint.com/cprogramming/) by
+* [C Tutorial](https://www.tutorialspoint.com/cprogramming/) by
   `Tutorialspoint`
-- [C Programming](https://en.wikibooks.org/wiki/C_Programming) by
+* [C Programming](https://en.wikibooks.org/wiki/C_Programming) by
   `Wikibooks`
 
 ### Submitting a fix
@@ -99,17 +101,17 @@ issue is optional).
 While we are not always able to write a driver for a chip, we still appreciate
 a request for new driver. It is more likely to happen when:
 
-- the chip is _cool_
-- the chip is easily available
-- the chip is affordable
+* the chip is _cool_
+* the chip is easily available
+* the chip is affordable
 
 ### Promoting the project
 
 If you find the project useful, we are interested in what you did with
 `esp-idf-lib`, and _how_ you did it.
 
-- Writing a blog post about your porject with `esp-idf-lib`
-- Mentioning the project in SNS
+* Writing a blog post about your porject with `esp-idf-lib`
+* Mentioning the project in SNS
 
 ### Writing code
 
@@ -150,6 +152,7 @@ Create a feature branch in your fork from the `master` branch.
 ```console
 git checkout master
 ```
+
 Check out the feature branch.
 
 ```console
@@ -170,10 +173,10 @@ See also [Writing a commit message](#writing-a-commit-message).
 At this point, our CI workflows will run to test the changes. The test
 workflows include:
 
-- building the documentation,
-- building all examples for all supported targets with all supported
+* building the documentation,
+* building all examples for all supported targets with all supported
   `esp-idf` versions, and
-- linting code and documentation
+* linting code and documentation
 
 You can see the test results in `Actions` page on your GitHub fork. To
 merge your changes to `master` branch, all the tests must pass.
@@ -201,26 +204,26 @@ Note that `git rebase` rewrites the commit history. You should avoid `git
 rebase` after you asked someone to review your code because the reviewer needs
 additional steps to ensure the review result is included.
 
-### Code style
+### C Code style
 
 We use a style for source files based on [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html)
 except some cases, notably brace wrapping. Here is a brief list of the styles.
 
-- Use `snake_case`, not `CamelCase`
-- Use `SNAKE_CASE` in uppercase for macro name, e.g. `MACRO_NAME`.
-- Use spaces. The indent width is four
-- Use `\n`, or `LF` for line breaks
-- Use `//` for inline comments. Use `/* */` for multi line comments after an
+* Use `snake_case`, not `CamelCase`
+* Use `SNAKE_CASE` in uppercase for macro name, e.g. `MACRO_NAME`.
+* Use spaces. The indent width is four
+* Use `\n`, or `LF` for line breaks
+* Use `//` for inline comments. Use `/* */` for multi line comments after an
   empty line
-- Break before braces in *most cases* (functions, conditionals, control
+* Break before braces in *most cases* (functions, conditionals, control
   statements, etc)
-- Always check given arguments
-- Always check return code, return value, or `errno`
-- Return `esp_err_t` from functions where possible
-- Document public functions, data types, and macros in header files
-- Use suffix `_t` for `typedef`, e.g. `foo_t`
-- Use suffix `_cb_t` for function `typedef`, e.g.`my_function_cb_t`
-- Use suffix `_s` for `struct`, e.g. `my_struct_s`
+* Always check given arguments
+* Always check return code, return value, or `errno`
+* Return `esp_err_t` from functions where possible
+* Document public functions, data types, and macros in header files
+* Use suffix `_t` for `typedef`, e.g. `foo_t`
+* Use suffix `_cb_t` for function `typedef`, e.g.`my_function_cb_t`
+* Use suffix `_s` for `struct`, e.g. `my_struct_s`
 
 The style should be followed for all new code. In general, code can be
 considered "new code" when it makes up about 50% or more of the file(s)
@@ -244,6 +247,38 @@ To format your code in-place, run:
 
 ```console
 clang-format10 -i components/example/example.c
+```
+
+### `markdown` Code style
+
+We use [the default `markdownlint` rules](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md)
+with some non-defaults. Our style can be found in [`.mdlstyle.rb`](.mdlstyle.rb).
+
+| Rule                                 | non-default options                          |
+| ------------------------------------ | -------------------------------------------- |
+| `MD003` - Header style               | use `#` for headers                          |
+| `MD007` - Unordered list indentation | indent with 4 spaces                         |
+| `MD013` - Line length                | ignore line length in code blocks and tables |
+
+In the CI, we use ruby version of `markdownlint`, or [`mdl`](https://rubygems.org/gems/mdl/)
+gem, but [markdownlint for node.js](https://github.com/DavidAnson/markdownlint)
+should also work.
+
+To test `markdown` style of a file, you need:
+
+* `ruby` 2.6
+* `bundler` 2.x
+
+```console
+bundle install
+bundle exec mdl path/to/file
+```
+
+The output shows path to the file, line number, and the rule.  An example
+output is shown below.
+
+```console
+examples/led_strip_spi/README.md:30: MD040 Fenced code blocks should have a language specified
 ```
 
 ### Typical issues you will face in developments
@@ -312,9 +347,9 @@ possible because you are working on multiple components, i.e. fixing common
 bugs in multiple components. In such cases, use `bugfix:`. Other commonly used
 prefix words are:
 
-- `feature:` for features, or improvements, in multiple components
-- `ci:` for fixes or improvements in the CI process
-- `doc:` for fixes and improvements in the documentation
+* `feature:` for features, or improvements, in multiple components
+* `ci:` for fixes or improvements in the CI process
+* `doc:` for fixes and improvements in the documentation
 
 These prefix words are for conventional purposes. Use common sense and make
 the commit message clear so that others can understand what the change is.
@@ -379,9 +414,9 @@ anyone and for any purpose.
 
 We accept permissive licenses such as:
 
-- ISC License
-- MIT License
-- BSD License
+* ISC License
+* MIT License
+* BSD License
 
 ### Acceptable license for new code
 
@@ -412,9 +447,9 @@ The following is a preferred wording of the license.
 
 We do NOT accept `copyleft` licenses such as:
 
-- GPL License
-- LGPL License
-- GNU Affero General Public License (AGPL)
+* GPL License
+* LGPL License
+* GNU Affero General Public License (AGPL)
 
 We do NOT accept _long_ licenses. A license is considered as _long_ when
 it has more than four clauses.
@@ -422,5 +457,5 @@ it has more than four clauses.
 We do NOT accept protective licenses that have additional restrictions, such
 as:
 
-- Apache license version 2 or later
-- various so-called _Shareware_ or _Freeware_
+* Apache license version 2 or later
+* various so-called _Shareware_ or _Freeware_

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,11 +254,13 @@ clang-format10 -i components/example/example.c
 We use [the default `markdownlint` rules](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md)
 with some non-defaults. Our style can be found in [`.mdlstyle.rb`](.mdlstyle.rb).
 
-| Rule                                 | non-default options                          |
-| ------------------------------------ | -------------------------------------------- |
-| `MD003` - Header style               | use `#` for headers                          |
-| `MD007` - Unordered list indentation | indent with 4 spaces                         |
-| `MD013` - Line length                | ignore line length in code blocks and tables |
+| Rule                                 | non-default options                            |
+| ------------------------------------ | ---------------------------------------------- |
+| `MD003` - Header style               | use `#` for headers                            |
+| `MD007` - Unordered list indentation | indent with 4 spaces                           |
+| `MD013` - Line length                | ignore line length in code blocks and tables   |
+| `MD024` - Multiple headers with the same content | `allow_different_nesting` is true  |
+| `MD029` - Ordered list item prefix   | `style` is `ordered`, i.e. incremental numbers |
 
 In the CI, we use ruby version of `markdownlint`, or [`mdl`](https://rubygems.org/gems/mdl/)
 gem, but [markdownlint for node.js](https://github.com/DavidAnson/markdownlint)

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,13 +1,17 @@
 # FAQ
 
-- [How to debug I2C-based drivers?](#how-to-debug-i2c-based-drivers)
-- [Why are semaphores used in i2cdev routines?](#why-are-semaphores-mutexes-used-in-ic2dev-routines)
-- [How can I connect multiple I2C devices?](#how-can-i-connect-multiple-i2c-devices)
-- [How can I change frequency of I2C clock?](#how-can-i-change-frequency-of-i2c-clock-at-default-frequency-my-device-is-unstable-or-not-working-at-all)
-- [How to use internal pull-up resistors?](#how-to-use-internal-pull-up-resistors)
-- [Can I use I2C device drivers from interrupts?](#can-i-use-i2c-device-drivers-from-interrupts)
+<!-- vim-markdown-toc GFM -->
 
-### How to debug I2C-based drivers?
+* [How to debug I2C-based drivers?](#how-to-debug-i2c-based-drivers)
+* [Why are semaphores (mutexes) used in i2cdev routines?](#why-are-semaphores-mutexes-used-in-i2cdev-routines)
+* [How can I connect multiple I2C devices?](#how-can-i-connect-multiple-i2c-devices)
+* [How can I change frequency of I2C clock? At default frequency my device is unstable or not working at all.](#how-can-i-change-frequency-of-i2c-clock-at-default-frequency-my-device-is-unstable-or-not-working-at-all)
+* [How to use internal pull-up resistors](#how-to-use-internal-pull-up-resistors)
+* [Can I use I2C device drivers from interrupts?](#can-i-use-i2c-device-drivers-from-interrupts)
+
+<!-- vim-markdown-toc -->
+
+## How to debug I2C-based drivers?
 
 Common causes of I2C issues are:
 
@@ -37,7 +41,7 @@ can decode I2C signals and display I2C transactions in human-readable way.
 If the driver does not work after these steps, please [let us
 know](https://github.com/UncleRus/esp-idf-lib/issues).
 
-### Why are semaphores (mutexes) used in i2cdev routines?
+## Why are semaphores (mutexes) used in i2cdev routines?
 
 i2cdev uses two types of mutexes: port and transactional.
 
@@ -75,15 +79,15 @@ xTaskCreate(task2, "task2", ....);
 These mutexes are used when single device operation requires several I2C
 transactions in a row.
 
-### How can I connect multiple I2C devices?
+## How can I connect multiple I2C devices?
 
 With i2cdev, you can use almost any way to connect I2C devices.
 
 For example, in the case of using SSD1306 and two MCP3428s, I would recommend
 connecting them like this:
 
-- 2 GPIO outputs on ESP32 for dedicated screen connection via I2C bus 0
-- 2 GPIO outputs to the second I2C bus, to which 2 MCP3428 are connected with
+* 2 GPIO outputs on ESP32 for dedicated screen connection via I2C bus 0
+* 2 GPIO outputs to the second I2C bus, to which 2 MCP3428 are connected with
   different addresses.
 
 If you need to connect more than one sensor with the same addresses and there
@@ -92,7 +96,7 @@ outputs instead of using the I2C multiplexer. i2cdev will take care of
 reconfiguring I2C driver to the according outputs when you exchange data
 with these devices.
 
-### How can I change frequency of I2C clock? At default frequency my device is unstable or not working at all.
+## How can I change frequency of I2C clock? At default frequency my device is unstable or not working at all.
 
 You can change the frequency after initializing the device handler, like this:
 
@@ -112,7 +116,7 @@ ESP_ERROR_CHECK(ads111x_set_data_rate(&dev, ADS111X_DATA_RATE_32)); // 32 sample
 ...
 ```
 
-### How to use internal pull-up resistors
+## How to use internal pull-up resistors
 
 Just enable them in `i2c_dev_t` config. For example:
 
@@ -126,9 +130,9 @@ ESP_ERROR_CHECK(ads111x_init_desc(&dev, addr, I2C_PORT, SDA_GPIO, SCL_GPIO));
 ...
 ```
 
-### Can I use I2C device drivers from interrupts?
+## Can I use I2C device drivers from interrupts?
 
-With default configuration you can't. Since the drivers use mutexes, this will crash the system.
-But you can disable use of any I2C mutexes (both port and device) in configuration: just enable
-CONFIG_I2CDEV_NOLOCK. Keep in mind that after enabling this option all i2c device drivers 
-will become non-thread safe.
+With default configuration you can't. Since the drivers use mutexes, this will
+crash the system.  But you can disable use of any I2C mutexes (both port and
+device) in configuration: just enable CONFIG_I2CDEV_NOLOCK. Keep in mind that
+after enabling this option all i2c device drivers will become non-thread safe.

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+gem "mdl"
+gem "rubocop"
+
+# gem "rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,53 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    chef-utils (17.0.242)
+      concurrent-ruby
+    concurrent-ruby (1.1.8)
+    kramdown (2.3.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    mdl (0.11.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      mixlib-cli (~> 2.1, >= 2.1.1)
+      mixlib-config (>= 2.2.1, < 4)
+      mixlib-shellout
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.9)
+      tomlrb
+    mixlib-shellout (3.2.5)
+      chef-utils
+    parallel (1.20.1)
+    parser (3.0.1.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rubocop (1.13.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.11.0)
+    tomlrb (2.0.1)
+    unicode-display_width (2.0.0)
+
+PLATFORMS
+  amd64-freebsd-13
+  x86_64-linux
+
+DEPENDENCIES
+  mdl
+  rubocop
+
+BUNDLED WITH
+   2.2.16

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Build the documentation](https://github.com/UncleRus/esp-idf-lib/workflows/Build%20the%20documentation/badge.svg)](https://github.com/UncleRus/esp-idf-lib/actions?query=workflow%3A%22Build+the+documentation%22)
 [![Docs Status](https://readthedocs.org/projects/esp-idf-lib/badge/?version=latest&style=flat)](https://esp-idf-lib.readthedocs.io/en/latest/)
 
-Components for Espressif ESP32 [ESP-IDF framework](https://github.com/espressif/esp-idf) and [ESP8266 RTOS SDK](https://github.com/espressif/ESP8266_RTOS_SDK).
+Components for Espressif ESP32 [ESP-IDF framework](https://github.com/espressif/esp-idf)
+and [ESP8266 RTOS SDK](https://github.com/espressif/ESP8266_RTOS_SDK).
 
 Part of them ported from [esp-open-rtos](https://github.com/SuperHouse/esp-open-rtos).
 
@@ -16,10 +17,11 @@ Part of them ported from [esp-open-rtos](https://github.com/SuperHouse/esp-open-
 | ESP32-S2 *[1]* | ESP-IDF            | master, v4.x, v.3.3.5
 | ESP8266  *[2]* | ESP8266 RTOS SDK   | master, v3.3
 
-[1] *Use "`idf.py set-target esp32s2`" before "`idf.py menuconfig`" to change the chip type.*
+[1] *Use "`idf.py set-target esp32s2`" before "`idf.py menuconfig`" to change
+the chip type.*
 
-[2] *Due to the incompatibility of ESP8266 drivers and hardware, some libraries are not*
-*supported on ESP8266 (see "ESP8266" column in the tables).*
+[2] *Due to the incompatibility of ESP8266 drivers and hardware, some
+libraries are not* *supported on ESP8266 (see "ESP8266" column in the tables).*
 
 ## How to use
 
@@ -29,7 +31,7 @@ Clone this repository somewhere, e.g.:
 
 ```Shell
 cd ~/myprojects/esp
-git clone https://github.com/UncleRus/esp-idf-lib.git 
+git clone https://github.com/UncleRus/esp-idf-lib.git
 ```
 
 Add path to components in your project makefile, e.g:
@@ -82,7 +84,8 @@ EXCLUDE_COMPONENTS := max7219 mcp23x17 led_strip
 include $(IDF_PATH)/make/project.mk
 ```
 
-See [GitHub examples](https://github.com/UncleRus/esp-idf-lib/tree/master/examples) or [GitLab examples](https://gitlab.com/UncleRus/esp-idf-lib/tree/master/examples).
+See [GitHub examples](https://github.com/UncleRus/esp-idf-lib/tree/master/examples)
+or [GitLab examples](https://gitlab.com/UncleRus/esp-idf-lib/tree/master/examples).
 
 ## Documentation
 
@@ -209,7 +212,6 @@ See [GitHub examples](https://github.com/UncleRus/esp-idf-lib/tree/master/exampl
 | **ds3502**     | Driver for nonvolatile digital potentiometer DS3502                     | MIT     | Yes     | Yes
 | **wiegand**    | Wiegand protocol receiver                                               | BSD     | Yes     | *No*
 
-
 ## Library maintainers
 
 - [Ruslan V. Uss](https://github.com/UncleRus)
@@ -217,10 +219,12 @@ See [GitHub examples](https://github.com/UncleRus/esp-idf-lib/tree/master/exampl
 
 ## Credits
 
-- [Tomoyuki Sakurai](https://github.com/trombik), developer of the LM75 and SK9822/APA102 drivers,
-  author of the RTOS SDK ESP82666 support, master CI
-- [Gunar Schorcht](https://github.com/gschorcht), developer of SHT3x, BME680 and CCS811 drivers
-- [Brian Schwind](https://github.com/bschwind), developer of TS2561 and TSL4531 drivers
+- [Tomoyuki Sakurai](https://github.com/trombik), developer of the LM75 and
+  SK9822/APA102 drivers, author of the RTOS SDK ESP82666 support, master CI
+- [Gunar Schorcht](https://github.com/gschorcht), developer of SHT3x, BME680
+  and CCS811 drivers
+- [Brian Schwind](https://github.com/bschwind), developer of TS2561 and
+  TSL4531 drivers
 - [Andrej Krutak](https://github.com/andree182), developer of BH1750 driver
 - Frank Bargstedt, developer of BMP180 driver
 - [sheinz](https://github.com/sheinz), developer of BMP280 driver
@@ -234,6 +238,7 @@ See [GitHub examples](https://github.com/UncleRus/esp-idf-lib/tree/master/exampl
 - [Pham Ngoc Thanh](https://github.com/panoti), developer of PCF8591 driver
 - [Lucio Tarantino](https://github.com/dianlight), developer of ADS111x driver
 - [Julian Dörner](https://github.com/juliandoerner), developer of TSL2591 driver
-- [FastLED community](https://github.com/FastLED), developers of `lib8tion`, `color` and `noise` libraries
+- [FastLED community](https://github.com/FastLED), developers of `lib8tion`,
+  `color` and `noise` libraries
 - [Erriez](https://github.com/Erriez), developer of MH-Z19B driver
 - [David Douard](https://github.com/douardda), developer of MH-Z19B driver

--- a/components/bme680/README.md
+++ b/components/bme680/README.md
@@ -2,10 +2,9 @@
 
 Forked from [original driver by Gunar Schorcht](https://github.com/gschorcht/bme680-esp-idf).
 
-The driver supports multiple BME680 sensors which are connected
-to the same or different I2C interfaces with different addresses.
-
-*SPI interface is not supported yet*
+The driver supports multiple BME680 sensors which are connected to the same or
+different I2C interfaces with different addresses.  *SPI interface is not
+supported yet*.
 
 It is for the usage with the ESP8266 and [ESP8266 RTOS SDK](https://github.com/espressif/ESP8266_RTOS_SDK)
 or ESP32 and [ESP-IDF](https://github.com/espressif/esp-idf.git).
@@ -17,7 +16,7 @@ pressure, humidity and gas sensors in only one unit.
 
 ## Communication interface
 
-The BME680 sensor can be connected using I2C. 
+The BME680 sensor can be connected using I2C.
 
 The I2C interface supports data rates up to 1 Mbps (ESP-IDF limitation). It is
 possible to connect multiple BME680 sensors with different I2C slave addresses
@@ -32,13 +31,13 @@ BME680 operates in two different modes, the **sleep mode** and the
 
 The sensor starts after power-up automatically in the *sleep mode* where it
 does not perform any measurement and consumes only 0.15 μA. Measurements are
-only done in *forced mode*. 
+only done in *forced mode*.
 
 **Please note:** There are two further undocumented modes, the *parallel* and
 the *sequential* mode. They can't be supported by the driver, since it is
 not clear what they do and how to use them.
 
-#### Measurement cylce
+### Measurement cylce
 
 To perform measurements, the BME680 sensor has to be triggered to switch to
 the **forced mode**. In this mode, it performs exactly one measurement of
@@ -57,15 +56,13 @@ To avoid the blocking of the user task during measurements, the measurement
 process is therefore separated into the following steps:
 
 1. Trigger the sensor with function `bme680_force_measurement()` to switch
-to *forced mode* in which it performs exactly one THPG measurement cycle.
-
+   to *forced mode* in which it performs exactly one THPG measurement cycle.
 2. Wait the measurement duration using function `vTaskDelay()` and the value
-returned from function `bme680_get_measurement_duration()` or wait as long
-as function `bme680_is_measuring` returns true.
-
+   returned from function `bme680_get_measurement_duration()` or wait as long
+   as function `bme680_is_measuring` returns true.
 3. Fetch the results as fixed point values with function
-`bme680_get_results_fixed()` or as floating point values with function
-`bme680_get_results_float()`.
+   `bme680_get_results_fixed()` or as floating point values with function
+   `bme680_get_results_float()`.
 
 ```C
 ...
@@ -84,7 +81,9 @@ if (bme680_force_measurement(sensor) == ESP_OK) // STEP 1
 }
 ...
 ```
+
 Alternatively, busy waiting can be realized using function `bme680_is_measuring()`.
+
 ```C
 ...
 if (bme680_force_measurement(sensor) == ESP_OK) // STEP 1
@@ -93,7 +92,7 @@ if (bme680_force_measurement(sensor) == ESP_OK) // STEP 1
     bool busy;
     do
     {
-    	ESP_ERROR_CHECK(bme680_is_measuring(sensor, &busy));
+        ESP_ERROR_CHECK(bme680_is_measuring(sensor, &busy));
     }
     while(busy);
 
@@ -125,7 +124,7 @@ Once the sensor has finished the measurement raw data are available at the senso
 Either function `bme680_get_results_fixed()` or function
 `bme680_get_results_float()` can be used to fetch the results. Both functions
 read raw data from the sensor and converts them into utilizable fixed point or
-floating point sensor values. 
+floating point sensor values.
 
 **Please note:** Conversion of raw sensor data into the final sensor values is
 based on very complex calculations that use a large number of calibration
@@ -155,18 +154,18 @@ are returned:
 | humidity       | 0           | 0.0
 | gas_resistance | 0           | 0.0
 
-
 ## Measurement settings
 
 The sensor allows to change a lot of measurement parameters.
 
-#### Oversampling rates
+### Oversampling rates
 
-To increase the resolution of raw sensor data, the sensor supports oversampling
-for temperature,  pressure, and humidity measurements. Using function
-`bme680_set_oversampling_rates()`, individual **oversampling rates** can be
-defined for these measurements. With an oversampling rate *osr*, the resolution
-of the according raw sensor data can be increased from 16 bit to 16+ld(*osr*) bit. 
+To increase the resolution of raw sensor data, the sensor supports
+oversampling for temperature,  pressure, and humidity measurements. Using
+function `bme680_set_oversampling_rates()`, individual **oversampling rates**
+can be defined for these measurements. With an oversampling rate *osr*, the
+resolution of the according raw sensor data can be increased from 16 bit to
+16+ld(*osr*) bit.
 
 Possible oversampling rates are 1x (default by the driver) 2x, 4x, 8x and 16x.
 It is also possible to define an oversampling rate of 0. This **deactivates**
@@ -179,7 +178,7 @@ ESP_ERROR_CHECK(bme680_set_oversampling_rates(sensor, osr_4x, osr_2x, osr_none))
 ...
 ```
 
-#### IIR Filter
+### IIR Filter
 
 The sensor also integrates an internal IIR filter (low pass filter) to reduce
 short-term changes in sensor output values caused by external disturbances.
@@ -205,7 +204,7 @@ bme680_set_filter_size(sensor, iir_size_0);
 ...
 ```
 
-#### Heater profile
+### Heater profile
 
 For the gas measurement, the sensor integrates a heater. Parameters for this
 heater are defined by **heater profiles**. The sensor supports up to 10 such
@@ -244,6 +243,7 @@ heater profiles for successive TPHG measurements using function
 
 For example, if there were 5 heater profiles defined with following code
 during the setup
+
 ```C
 bme680_set_heater_profile(sensor, 0, 200, 100);
 bme680_set_heater_profile(sensor, 1, 250, 120);
@@ -271,7 +271,7 @@ while (1)
     uint32_t duration;
     bme680_get_measurement_duration(sensor, &duration);
 
-    // trigger the sensor to start one TPHG measurement cycle 
+    // trigger the sensor to start one TPHG measurement cycle
     if (bme680_force_measurement(sensor) == ESP_OK)
     {
         vTaskDelay(duration);
@@ -285,7 +285,7 @@ while (1)
 ...
 ```
 
-#### Ambient temperature
+### Ambient temperature
 
 The heater resistance calculation algorithm takes into account the ambient
 temperature of the sensor. Using function `bme680_set_ambient_temperature()`,
@@ -311,7 +311,7 @@ configurations.
 
 First figure shows the configuration with only one sensor at I2C bus 0.
 
-```
+```text
  +------------------+   +----------+
  | ESP8266 / ESP32  |   | BME680   |
  |                  |   |          |
@@ -323,7 +323,7 @@ First figure shows the configuration with only one sensor at I2C bus 0.
 Next figure shows a possible configuration with two I2C buses. In that case,
 the sensors can have same or different I2C slave addresses.
 
-```
+```text
  +------------------+   +----------+
  | ESP8266 / ESP32  |   | BME680_1 |
  |                  |   |          |

--- a/components/ccs811/README.md
+++ b/components/ccs811/README.md
@@ -1,6 +1,6 @@
-# Driver for the ams CCS811 digital gas sensor for monitoring indoor air quality.
+# Driver for the ams CCS811 digital gas sensor for monitoring indoor air quality
 
-The driver is for the usage with the ESP-IDF. 
+The driver is for the usage with the ESP-IDF.
 
 ## About the sensor
 
@@ -70,18 +70,18 @@ if (ccs811_init(&sensor) == ESP_OK)
 **Please note:**
 
 1. After setting the mode, the sensor is in conditioning period that needs up
-to 20 minutes, before accurate readings are generated, see the data sheet for
-more details.
+   to 20 minutes, before accurate readings are generated, see the data sheet for
+   more details.
 
 2. During the early-live (burn-in) period, the CCS811 sensor should run for
-48 hours in the selected mode of operation to ensure sensor performance is
-stable, see the datasheet for more details.
+   48 hours in the selected mode of operation to ensure sensor performance is
+   stable, see the datasheet for more details.
 
 3. When the sensor operating mode is changed to a new mode with a lower sample
-rate, e.g., from *Pulse Heating Mode* (`CCS811_MODE_10S`) to *Low Power Pulse
-Heating Mode* (`CCS811_MODE_60S`), it should be placed in *Idle, Low Current
-Mode* (`CCS811_MODE_IDLE`) for at least 10 minutes before enabling the new
-mode.
+   rate, e.g., from *Pulse Heating Mode* (`CCS811_MODE_10S`) to *Low Power Pulse
+   Heating Mode* (`CCS811_MODE_60S`), it should be placed in *Idle, Low Current
+   Mode* (`CCS811_MODE_IDLE`) for at least 10 minutes before enabling the new
+   mode.
 
 When a sensor operating mode is changed to a new mode with a higher sample
 rate, e.g., from *Low Power Pulse Heating Mode* (`CCS811_MODE_60S`) to
@@ -126,14 +126,14 @@ are returned and the error code CCS811_ERR_NO_NEW_DATA.
 **Please note:**
 
 1. In *Constant Power Mode* with measurements every 250 ms (`CCS811_MODE_250MS`)
-only raw data are available.
+   only raw data are available.
 
 2. The rate of fetching data must not be greater than the rate of measurement.
-Due to the sensor mode timing tolerance of 2 %, the rate of fetching data
-should be lower than the measurement rate.
+   Due to the sensor mode timing tolerance of 2 %, the rate of fetching data
+   should be lower than the measurement rate.
 
 3. If the function is called and no new data are available, the results of the
-latest measurement are returned and error code CCS811_ERR_NO_NEW_DATA is set.
+   latest measurement are returned and error code CCS811_ERR_NO_NEW_DATA is set.
 
 ### Compensation
 
@@ -162,7 +162,9 @@ reference resistor (R_REF). Function `ccs811_get_ntc_resistance()` can be used
 to fetch the current resistance of R_NTC. It uses the resistance of R_REF and
 measured voltages V_REF and V_NTV with the following equation:
 
+```text
           R_NTC = R_REF / V_REF * V_NTC
+```
 
 Using the data sheet of the NTC, the ambient temperature can be calculated. See
 application note ams AN000372 for more details. For example, with Adafruit
@@ -226,9 +228,9 @@ The interrupt is disabled by default and can be enabled with function
 `ccs811_set_eco2_thresholds()`. The ranges are defined by parameters *low* and
 *high* as following
 
-  - **LOW** - below parameter value *low*
-  - **MEDIUM** - between parameter values *low* and *high*
-  - **HIGH** - above parameter value *high* is range **HIGH**.
+- **LOW** - below parameter value *low*
+- **MEDIUM** - between parameter values *low* and *high*
+- **HIGH** - above parameter value *high* is range **HIGH**.
 
 If all parameters have valid values, the function sets the thresholds and
 enables the data ready interrupt. Using 0 for all parameters disables the

--- a/components/mhz19b/README.md
+++ b/components/mhz19b/README.md
@@ -3,11 +3,10 @@
 This driver is heavily inspired from [Erriez MH-Z19B CO2 sensor library for
 Arduino](https://github.com/Erriez/ErriezMHZ19B).
 
-It uses an UART serial port to communicate with the sensor. Since the UART must
-configured a specific way (9600 8N1), the `mhz19b_init()` takes care of configuring it.
-It will however not start detecting/reading from the sensor. This must be done. Typical
-usage would be:
-
+It uses an UART serial port to communicate with the sensor. Since the UART
+must configured a specific way (9600 8N1), the `mhz19b_init()` takes care of
+configuring it.  It will however not start detecting/reading from the sensor.
+This must be done. Typical usage would be:
 
 ```C
 [...]
@@ -19,43 +18,43 @@ usage would be:
 
 void app_main(void)
 {
-	int16_t co2;
-	mhz19b_dev_t dev;
-	char version[6];
-	uint16_t range;
-	bool autocal;
+    int16_t co2;
+    mhz19b_dev_t dev;
+    char version[6];
+    uint16_t range;
+    bool autocal;
 
-	mhz19b_init(&dev, UART_NUM_1, MHZ19B_TX, MHZ19B_RX);
+    mhz19b_init(&dev, UART_NUM_1, MHZ19B_TX, MHZ19B_RX);
 
-	while (!mhz19b_detect(&dev))
-	{
-		ESP_LOGI(TAG, "MHZ-19B not detected, waiting...");
-		vTaskDelay(1000 / portTICK_RATE_MS);
-	}
+    while (!mhz19b_detect(&dev))
+    {
+        ESP_LOGI(TAG, "MHZ-19B not detected, waiting...");
+        vTaskDelay(1000 / portTICK_RATE_MS);
+    }
 
-	mhz19b_get_version(&dev, version, 5);
-	ESP_LOGI(TAG, "MHZ-19B firmware version: %s", version);
-	ESP_LOGI(TAG, "MHZ-19B set range and autocal");
+    mhz19b_get_version(&dev, version, 5);
+    ESP_LOGI(TAG, "MHZ-19B firmware version: %s", version);
+    ESP_LOGI(TAG, "MHZ-19B set range and autocal");
 
-	mhz19b_set_range(&dev, MHZ19B_RANGE_5000);
-	mhz19b_set_auto_calibration(&dev, false);
+    mhz19b_set_range(&dev, MHZ19B_RANGE_5000);
+    mhz19b_set_auto_calibration(&dev, false);
 
-	mhz19b_get_range(&dev, &range);
-	ESP_LOGI(TAG, "  range: %d", range);
+    mhz19b_get_range(&dev, &range);
+    ESP_LOGI(TAG, "  range: %d", range);
 
-	mhz19b_get_auto_calibration(&dev, &autocal);
-	ESP_LOGI(TAG, "  autocal: %s", autocal ? "ON" : "OFF");
+    mhz19b_get_auto_calibration(&dev, &autocal);
+    ESP_LOGI(TAG, "  autocal: %s", autocal ? "ON" : "OFF");
 
-	while (mhz19b_is_warming_up(&dev))
-	{
-		ESP_LOGI(TAG, "MHZ-19B is warming up");
-		vTaskDelay(1000 / portTICK_RATE_MS);
-	}
+    while (mhz19b_is_warming_up(&dev))
+    {
+        ESP_LOGI(TAG, "MHZ-19B is warming up");
+        vTaskDelay(1000 / portTICK_RATE_MS);
+    }
 
     while (1) {
-		mhz19b_read_CO2(&dev, &co2);
-		ESP_LOGI(TAG, "CO2: %d", co2);
-		vTaskDelay(5000 / portTICK_RATE_MS);
+        mhz19b_read_CO2(&dev, &co2);
+        ESP_LOGI(TAG, "CO2: %d", co2);
+        vTaskDelay(5000 / portTICK_RATE_MS);
     }
 }
 

--- a/components/sht3x/README.md
+++ b/components/sht3x/README.md
@@ -1,4 +1,4 @@
 # Driver for SHT3x digital temperature and humidity sensor
 
-This driver is fork of [original SHT3x driver](https://github.com/gschorcht/sht3x-esp-idf) by Gunar Schorcht (@gschorcht),
-made to be compatible with the i2cdev library.
+This driver is fork of [original SHT3x driver](https://github.com/gschorcht/sht3x-esp-idf)
+by Gunar Schorcht (@gschorcht), made to be compatible with the i2cdev library.

--- a/examples/ads1115/README.md
+++ b/examples/ads1115/README.md
@@ -1,7 +1,9 @@
-# Example for ADS1115 
-The datasheet can be found [here](https://www.ti.com/product/ADS1115). 
+# Example for ADS1115
 
-## Connections: 
+The datasheet can be found [here](https://www.ti.com/product/ADS1115).
+
+## Connections
+
 Make the connections as below:
 
 | S. No. | ADS 1115 | ESP 32            |
@@ -12,4 +14,6 @@ Make the connections as below:
 | 4.     | SDA      | D17               |
 | 5.     | A0-A3    | analog input      |
 
-This example specifically demonstrates the simultaneous use of multiple devices, which is why the default `DEV_COUNT` is 2. If you are using only one IC then please change the value of `DEV_COUNT` to 1.
+This example specifically demonstrates the simultaneous use of multiple
+devices, which is why the default `DEV_COUNT` is 2. If you are using only one
+IC then please change the value of `DEV_COUNT` to 1.

--- a/examples/ds3231/README.md
+++ b/examples/ds3231/README.md
@@ -1,9 +1,9 @@
-## What the example does
+# What the example does
 
 The example sets (hard-coded) date and time. In the loop, it reads temperature
 and time from the device, prints them to the serial console.
 
-```
+```console
 I (28) boot: ESP-IDF v4.0-dev-1446-g6b169d473 2nd stage bootloader
 I (28) boot: compile time 19:12:04
 I (29) boot: Enabling RNG early entropy source...

--- a/examples/hd44780_i2c_scroll/README.md
+++ b/examples/hd44780_i2c_scroll/README.md
@@ -1,3 +1,4 @@
-## What the example does
+# What the example does
 
-It prints "LEFT scroll" or "RIGHT scroll" to the LCD, scrolls the text, and repeat.
+It prints "LEFT scroll" or "RIGHT scroll" to the LCD, scrolls the text, and
+repeat.

--- a/examples/led_effects/README.md
+++ b/examples/led_effects/README.md
@@ -5,7 +5,7 @@ This example works with a 16x16 matrix of WS2812b LEDs (256 pieces in total):
 Connect DIN input of matrix to GPIO 5 of ESP32.
 
 Keep in mind that the power consumption of so many LEDs can be overwhelming!
-Use a 5V power supply with high output current to power the matrix or lower 
+Use a 5V power supply with high output current to power the matrix or lower
 `LED_BRIGHTNESS`.
 
 Example uses `frambuffer` component to render some effects.

--- a/examples/led_strip_spi/README.md
+++ b/examples/led_strip_spi/README.md
@@ -27,7 +27,7 @@ default is 8 pixels.
 direction of data flow is correct. The `GPIO`s must be connected to the first
 LED. My strip has arrows on the strip like below.
 
-```
+```text
 --------------------- Data flow ------------------>
 
                   .--------------------------.

--- a/examples/lm75/README.md
+++ b/examples/lm75/README.md
@@ -1,4 +1,4 @@
-## What the example does
+# What the example does
 
 The example application initializes LM75 device. In a loop, it reads
 temperature value from the device, prints it to the console. During the loop,
@@ -24,14 +24,14 @@ For ESP32, no additional configuration is necessary.
 
 For ESP8266, the following non-default configuration is necessary.
 
-```
+```text
 # [Component config] > [Newlib] > [newlib level], set `normal`
 CONFIG_NEWLIB_LIBRARY_LEVEL_NORMAL=y
 ```
 
 ## Example output
 
-```
+```console
 I (71) boot: Partition Table:
 I (76) boot: ## Label            Usage          Type ST Offset   Length
 I (87) boot:  0 nvs              WiFi data        01 02 00009000 00006000

--- a/examples/pca9685/README.md
+++ b/examples/pca9685/README.md
@@ -4,5 +4,5 @@ In this example, PWM frequency is first set to ~1500Hz
 and then PWM values for channels 0 and 3 start to change
 continuously.
 
- - Channel 0: from 0 to 4096
- - Channel 3: from 4096 downto 0
+- Channel 0: from 0 to 4096
+- Channel 3: from 4096 downto 0

--- a/examples/tsl2561/README.md
+++ b/examples/tsl2561/README.md
@@ -1,9 +1,9 @@
-## What the example does
+# What the example does
 
 The example continually prints illuminance in lux to serial console. An
 example:
 
-```
+```console
 I (43) boot: ESP-IDF v3.2-18-gf1b9e15b-dirty 2nd stage bootloader
 I (43) boot: compile time 15:41:21
 I (44) qio_mode: Enabling default flash chip QIO
@@ -25,8 +25,8 @@ I (281) system_api: Base MAC address is not set, read default base MAC address f
 I (291) system_api: Base MAC address is not set, read default base MAC address from BLK0 of EFUSE
 I (481) phy_init: phy ver: 1055_12
 I (491) reset_reason: RTC reset 2 wakeup 0 store 0, reason is 2
-I (491) gpio: GPIO[4]| InputEn: 0| OutputEn: 1| OpenDrain: 1| Pullup: 0| Pulldown: 0| Intr:0 
-I (501) gpio: GPIO[5]| InputEn: 0| OutputEn: 1| OpenDrain: 1| Pullup: 0| Pulldown: 0| Intr:0 
+I (491) gpio: GPIO[4]| InputEn: 0| OutputEn: 1| OpenDrain: 1| Pullup: 0| Pulldown: 0| Intr:0
+I (501) gpio: GPIO[5]| InputEn: 0| OutputEn: 1| OpenDrain: 1| Pullup: 0| Pulldown: 0| Intr:0
 Found TSL2561 in package T/FN/CL
 Lux: 1245
 Lux: 1252

--- a/examples/tsl2591_interrupt/README.md
+++ b/examples/tsl2591_interrupt/README.md
@@ -1,9 +1,9 @@
-## What the example does
+# What the example does
 
 The example continually prints illuminance in lux to serial console and reacts to
 als and als no persistence interrupts.
 
-```
+```console
 I (33) boot: ESP-IDF v4.3-dev-2136-gb0150615d 2nd stage bootloader
 I (33) boot: compile time 14:49:46
 I (33) boot: chip revision: 1

--- a/examples/tsl2591_simple/README.md
+++ b/examples/tsl2591_simple/README.md
@@ -1,9 +1,9 @@
-## What the example does
+# What the example does
 
 The example continually prints illuminance in lux to serial console. An
 example:
 
-```
+```console
 I (33) boot: ESP-IDF v4.3-dev-2136-gb0150615d 2nd stage bootloader
 I (33) boot: compile time 14:46:52
 I (33) boot: chip revision: 1


### PR DESCRIPTION
fixes #192 

the implementation still has issues (issues in the upstream, or `mdl`). however, it is still better than nothing.