### PR TITLE
mzh19b: fix serial buffer length used by the driver

### DIFF
--- a/components/mhz19b/mhz19b.h
+++ b/components/mhz19b/mhz19b.h
@@ -72,7 +72,8 @@ typedef struct
 
 //! Fixed 9 Bytes response
 #define MHZ19B_SERIAL_RX_BYTES          9
-#define MHZ19B_SERIAL_BUF_LEN           16
+//! 128 is the minimal value the UART driver will accept (at least on esp32)
+#define MHZ19B_SERIAL_BUF_LEN           128
 
 //! Response timeout between 15..120 ms at 9600 baud works reliable for all commands
 #define MHZ19B_SERIAL_RX_TIMEOUT_MS     120


### PR DESCRIPTION
even if we don't really need that much buffer space, a minimal value of 128
is required by the ESP32 at execution time.