### PR TITLE
Ds18x20 improvements

### DIFF
--- a/components/ds18x20/ds18x20.c
+++ b/components/ds18x20/ds18x20.c
@@ -133,7 +133,7 @@ esp_err_t ds18x20_read_scratchpad(gpio_num_t pin, ds18x20_addr_t addr, uint8_t *
     return ESP_OK;
 }
 
-esp_err_t ds18x20_read_temperature(gpio_num_t pin, ds18x20_addr_t addr, float *temperature)
+esp_err_t ds18b20_read_temperature(gpio_num_t pin, ds18x20_addr_t addr, float *temperature)
 {
     CHECK_ARG(temperature);
 
@@ -144,15 +144,53 @@ esp_err_t ds18x20_read_temperature(gpio_num_t pin, ds18x20_addr_t addr, float *t
 
     temp = scratchpad[1] << 8 | scratchpad[0];
 
-    if ((uint8_t)addr == DS18B20_FAMILY_ID)
-        *temperature = ((float)temp * 625.0) / 10000;
-    else
-    {
-        temp = ((temp & 0xfffe) << 3) + (16 - scratchpad[6]) - 4;
-        *temperature = ((float)temp * 625.0) / 10000 - 0.25;
-    }
+    *temperature = ((float)temp * 625.0) / 10000;
 
     return ESP_OK;
+}
+
+esp_err_t ds18s20_read_temperature(gpio_num_t pin, ds18x20_addr_t addr, float *temperature)
+{
+    CHECK_ARG(temperature);
+
+    uint8_t scratchpad[8];
+    int16_t temp;
+
+    CHECK(ds18x20_read_scratchpad(pin, addr, scratchpad));
+
+    temp = scratchpad[1] << 8 | scratchpad[0];
+
+    temp = ((temp & 0xfffe) << 3) + (16 - scratchpad[6]) - 4;
+    *temperature = ((float)temp * 625.0) / 10000 - 0.25;
+
+    return ESP_OK;
+}
+
+esp_err_t ds18x20_read_temperature(gpio_num_t pin, ds18x20_addr_t addr, float *temperature)
+{
+    if ((uint8_t)addr == DS18B20_FAMILY_ID) {
+        return ds18b20_read_temperature(pin, addr, temperature);
+    }
+    else
+    {
+        return ds18s20_read_temperature(pin, addr, temperature);
+    }
+}
+
+esp_err_t ds18b20_measure_and_read(gpio_num_t pin, ds18x20_addr_t addr, float *temperature)
+{
+    CHECK_ARG(temperature);
+
+    CHECK(ds18x20_measure(pin, addr, true));
+    return ds18b20_read_temperature(pin, addr, temperature);
+}
+
+esp_err_t ds18s20_measure_and_read(gpio_num_t pin, ds18x20_addr_t addr, float *temperature)
+{
+    CHECK_ARG(temperature);
+
+    CHECK(ds18x20_measure(pin, addr, true));
+    return ds18s20_read_temperature(pin, addr, temperature);
 }
 
 esp_err_t ds18x20_measure_and_read(gpio_num_t pin, ds18x20_addr_t addr, float *temperature)

--- a/components/ds18x20/ds18x20.h
+++ b/components/ds18x20/ds18x20.h
@@ -241,6 +241,35 @@ esp_err_t ds18x20_measure_and_read_multi(gpio_num_t pin, ds18x20_addr_t *addr_li
  */
 esp_err_t ds18x20_read_scratchpad(gpio_num_t pin, ds18x20_addr_t addr, uint8_t *buffer);
 
+/**
+ * @brief Write the scratchpad data for a particular ds18x20 device.
+ *
+ * @param pin     The GPIO pin connected to the ds18x20 device
+ * @param addr    The 64-bit address of the device to write. This can be set
+ *                to ::DS18X20_ANY to read any device on the bus (but note
+ *                that this will only work if there is exactly one device
+ *                connected, or they will corrupt each others' transmissions)
+ * @param buffer  An 3-byte buffer to hold the data to write
+ *
+ * @returns `ESP_OK` if the command was successfully issued
+ */
+esp_err_t ds18x20_write_scratchpad(gpio_num_t pin, ds18x20_addr_t addr, uint8_t *buffer);
+
+/**
+ * @brief Issue the copy scratchpad command, copying current scratchpad to
+ *        EEPROM.
+ *
+ * @param pin     The GPIO pin connected to the ds18x20 device
+ * @param addr    The 64-bit address of the device to command. This can be set
+ *                to ::DS18X20_ANY to read any device on the bus (but note
+ *                that this will only work if there is exactly one device
+ *                connected, or they will corrupt each others' transmissions)
+ *
+ * @returns `ESP_OK` if the command was successfully issued
+ */
+esp_err_t ds18x20_copy_scratchpad(gpio_num_t pin, ds18x20_addr_t addr);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/ds18x20/ds18x20.h
+++ b/components/ds18x20/ds18x20.h
@@ -129,6 +129,40 @@ esp_err_t ds18x20_measure(gpio_num_t pin, ds18x20_addr_t addr, bool wait);
 esp_err_t ds18x20_read_temperature(gpio_num_t pin, ds18x20_addr_t addr, float *temperature);
 
 /**
+ * @brief Read the value from the last CONVERT_T operation (ds18b20 version).
+ *
+ * This should be called after ds18x20_measure() to fetch the result of the
+ * temperature measurement.
+ *
+ * @param pin         The GPIO pin connected to the ds18x20 device
+ * @param addr        The 64-bit address of the device to read. This can be set
+ *                    to ::DS18X20_ANY to read any device on the bus (but note
+ *                    that this will only work if there is exactly one device
+ *                    connected, or they will corrupt each others' transmissions)
+ * @param temperature The temperature in degrees Celsius
+ *
+ * @returns `ESP_OK` if the command was successfully issued
+ */
+esp_err_t ds18b20_read_temperature(gpio_num_t pin, ds18x20_addr_t addr, float *temperature);
+
+/**
+ * @brief Read the value from the last CONVERT_T operation (ds18s20 version).
+ *
+ * This should be called after ds18x20_measure() to fetch the result of the
+ * temperature measurement.
+ *
+ * @param pin         The GPIO pin connected to the ds18x20 device
+ * @param addr        The 64-bit address of the device to read. This can be set
+ *                    to ::DS18X20_ANY to read any device on the bus (but note
+ *                    that this will only work if there is exactly one device
+ *                    connected, or they will corrupt each others' transmissions)
+ * @param temperature The temperature in degrees Celsius
+ *
+ * @returns `ESP_OK` if the command was successfully issued
+ */
+esp_err_t ds18s20_read_temperature(gpio_num_t pin, ds18x20_addr_t addr, float *temperature);
+
+/**
  * @brief Read the value from the last CONVERT_T operation for multiple devices.
  *
  * This should be called after ds18x20_measure() to fetch the result of the
@@ -143,6 +177,28 @@ esp_err_t ds18x20_read_temperature(gpio_num_t pin, ds18x20_addr_t addr, float *t
  * @returns `ESP_OK` if all temperatures were fetched successfully
  */
 esp_err_t ds18x20_read_temp_multi(gpio_num_t pin, ds18x20_addr_t *addr_list, size_t addr_count, float *result_list);
+
+/** Perform a ds18x20_measure() followed by ds18s20_read_temperature()
+ *
+ *  @param pin         The GPIO pin connected to the ds18s20 device
+ *  @param addr        The 64-bit address of the device to read. This can be set
+ *                     to ::DS18X20_ANY to read any device on the bus (but note
+ *                     that this will only work if there is exactly one device
+ *                     connected, or they will corrupt each others' transmissions)
+ *  @param temperature The temperature in degrees Celsius
+ */
+esp_err_t ds18s20_measure_and_read(gpio_num_t pin, ds18x20_addr_t addr, float *temperature);
+
+/** Perform a ds18x20_measure() followed by ds18b20_read_temperature()
+ *
+ *  @param pin         The GPIO pin connected to the ds18x20 device
+ *  @param addr        The 64-bit address of the device to read. This can be set
+ *                     to ::DS18X20_ANY to read any device on the bus (but note
+ *                     that this will only work if there is exactly one device
+ *                     connected, or they will corrupt each others' transmissions)
+ *  @param temperature The temperature in degrees Celsius
+ */
+esp_err_t ds18b20_measure_and_read(gpio_num_t pin, ds18x20_addr_t addr, float *temperature);
 
 /** Perform a ds18x20_measure() followed by ds18x20_read_temperature()
  *


### PR DESCRIPTION
1. Refactor generic temperature read into model family specific reads to avoid having to read and cache the specific model number - just pass it DS18X20_ANY and be done with it.
2. Add scratchpad write and copy commands so you can modify the conversion config and save it to not have to reset it every boot.