### PR TITLE
led_strip_spi: Add brightness support and update example

### DIFF
--- a/components/led_strip_spi/led_strip_spi.c
+++ b/components/led_strip_spi/led_strip_spi.c
@@ -317,18 +317,33 @@ esp_err_t led_strip_spi_flush(led_strip_spi_t*strip)
 
 esp_err_t led_strip_spi_set_pixel(led_strip_spi_t *strip, const int index, const rgb_t color)
 {
-#if CONFIG_LED_STRIP_SPI_USING_SK9822
-    return led_strip_spi_set_pixel_sk9822(strip, index, color);
-#endif
-    return ESP_ERR_NOT_SUPPORTED;
+    return led_strip_spi_set_pixel_brightness(strip, index, color, LED_STRIP_SPI_MAX_BRIGHTNESS);
 }
 
 esp_err_t led_strip_spi_set_pixels(led_strip_spi_t*strip, const int start, size_t len, const rgb_t data)
 {
+    return led_strip_spi_set_pixels_brightness(strip, start, len, data, LED_STRIP_SPI_MAX_BRIGHTNESS);
+}
+
+esp_err_t led_strip_spi_fill(led_strip_spi_t*strip, size_t start, size_t len, rgb_t color)
+{
+    return led_strip_spi_fill_brightness(strip, start, len, color, LED_STRIP_SPI_MAX_BRIGHTNESS);
+}
+
+esp_err_t led_strip_spi_set_pixel_brightness(led_strip_spi_t *strip, const int index, const rgb_t color, const uint8_t brightness)
+{
+#if CONFIG_LED_STRIP_SPI_USING_SK9822
+    return led_strip_spi_set_pixel_sk9822(strip, index, color, brightness);
+#endif
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+esp_err_t led_strip_spi_set_pixels_brightness(led_strip_spi_t*strip, const int start, size_t len, const rgb_t data, const uint8_t brightness)
+{
     esp_err_t err = ESP_FAIL;
 
     for (int i = 0; i < len; i++) {
-        err = led_strip_spi_set_pixel(strip, start + i, data);
+        err = led_strip_spi_set_pixel_brightness(strip, start + i, data, brightness);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "led_strip_spi_set_pixel(): %s", esp_err_to_name(err));
             goto fail;
@@ -338,12 +353,12 @@ fail:
     return err;
 }
 
-esp_err_t led_strip_spi_fill(led_strip_spi_t*strip, size_t start, size_t len, rgb_t color)
+esp_err_t led_strip_spi_fill_brightness(led_strip_spi_t*strip, size_t start, size_t len, rgb_t color, const uint8_t brightness)
 {
     CHECK_ARG(strip && len && start + len <= strip->length);
 
     for (size_t i = start; i < len; i++) {
-        CHECK(led_strip_spi_set_pixel(strip, i, color));
+        CHECK(led_strip_spi_set_pixel_brightness(strip, i, color, brightness));
     }
     return ESP_OK;
 }

--- a/components/led_strip_spi/led_strip_spi.h
+++ b/components/led_strip_spi/led_strip_spi.h
@@ -69,6 +69,11 @@ extern "C" {
 #endif
 
 /**
+ * Maximum brightness value for a pixel.
+ */
+#define LED_STRIP_SPI_MAX_BRIGHTNESS (100)
+
+/**
  * @brief Setup the driver
  *
  * This method must be called before any other led_strip_spi methods
@@ -113,6 +118,20 @@ esp_err_t led_strip_spi_flush(led_strip_spi_t*strip);
 esp_err_t led_strip_spi_set_pixel(led_strip_spi_t *strip, const int num, const rgb_t color);
 
 /**
+ * @brief Set color of single LED in strip.
+ *
+ * This function does not actually change colors of the LEDs.
+ * Call ::led_strip_spi_flush() to send buffer to the LEDs.
+ *
+ * @param strip Descriptor of LED strip
+ * @param num LED number, [0:strip.length - 1].
+ * @param color RGB color
+ * @param brightness Brightness of the LED, [0:100].
+ * @return `ESP_OK` on success
+ */
+esp_err_t led_strip_spi_set_pixel_brightness(led_strip_spi_t *strip, const int num, const rgb_t color, const uint8_t brightness);
+
+/**
  * @brief Set colors of multiple LEDs
  *
  * This function does not actually change colors of the LEDs.
@@ -125,6 +144,21 @@ esp_err_t led_strip_spi_set_pixel(led_strip_spi_t *strip, const int num, const r
  * @return `ESP_OK` on success
  */
 esp_err_t led_strip_spi_set_pixels(led_strip_spi_t*strip, const int start, size_t len, const rgb_t data);
+
+/**
+ * @brief Set colors of multiple LEDs
+ *
+ * This function does not actually change colors of the LEDs.
+ * Call ::led_strip_spi_flush() to send buffer to the LEDs.
+ *
+ * @param strip Descriptor of LED strip
+ * @param start First LED index, 0-based
+ * @param len Number of LEDs
+ * @param data Pointer to RGB data
+ * @param brightness Brightness of the LED, [0:100].
+ * @return `ESP_OK` on success
+ */
+esp_err_t led_strip_spi_set_pixels_brightness(led_strip_spi_t*strip, const int start, size_t len, const rgb_t data, const uint8_t brightness);
 
 /**
  * @brief Set multiple LEDs to the one color.
@@ -140,6 +174,20 @@ esp_err_t led_strip_spi_set_pixels(led_strip_spi_t*strip, const int start, size_
  */
 esp_err_t led_strip_spi_fill(led_strip_spi_t*strip, size_t start, size_t len, rgb_t color);
 
+/**
+ * @brief Set multiple LEDs to the one color.
+ *
+ * This function does not actually change colors of the LEDs.
+ * Call ::led_strip_spi_flush() to send buffer to the LEDs.
+ *
+ * @param strip Descriptor of LED strip
+ * @param start First LED index, 0-based
+ * @param len Number of LEDs
+ * @param color RGB color
+ * @param brightness Brightness of the LEDs, [0:100].
+ * @return `ESP_OK` on success
+ */
+esp_err_t led_strip_spi_fill_brightness(led_strip_spi_t*strip, size_t start, size_t len, rgb_t color, const uint8_t brightness);
 #ifdef __cplusplus
 }
 #endif

--- a/components/led_strip_spi/led_strip_spi_sk9822.c
+++ b/components/led_strip_spi/led_strip_spi_sk9822.c
@@ -26,10 +26,19 @@
 #include "led_strip_spi.h"
 #include "led_strip_spi_sk9822.h"
 
-esp_err_t led_strip_spi_set_pixel_sk9822(led_strip_spi_t *strip, size_t num, rgb_t color)
+esp_err_t led_strip_spi_set_pixel_sk9822(led_strip_spi_t *strip, size_t num, rgb_t color, uint8_t brightness)
 {
     int index = (num + 1) * 4;
-    ((uint8_t *)strip->buf)[index    ] = LED_STRIP_SPI_FRAME_SK9822_LED_MSB3 + 1; // XXX FIXME brightness control
+    uint8_t cooked_brightness = 0;
+    /* Don't divided the range equal instead, the bottom 10 % is actually 0 brightness 
+       then every 3 percent after that increase the brightness level by 1 */
+    if (brightness >= 100) {
+        cooked_brightness = 31;
+    } else if (brightness > 7){
+        cooked_brightness = (brightness - 7) / 3;
+    }
+    ((uint8_t *)strip->buf)[index    ] = LED_STRIP_SPI_FRAME_SK9822_LED_MSB3 | 
+                                         (cooked_brightness & ((1 << LED_STRIP_SPI_FRAME_SK9822_LED_BRIGHTNESS_BITS) - 1));
     ((uint8_t *)strip->buf)[index + 1] = color.b;
     ((uint8_t *)strip->buf)[index + 2] = color.g;
     ((uint8_t *)strip->buf)[index + 3] = color.r;

--- a/components/led_strip_spi/led_strip_spi_sk9822.h
+++ b/components/led_strip_spi/led_strip_spi_sk9822.h
@@ -62,6 +62,8 @@ extern "C" {
 
 #define LED_STRIP_SPI_FRAME_SK9822_LED_MSB3    (0xE0)   ///< A magic number of [31:29] in LED frames. The bits must be 1 (APA102, SK9822)
 
+#define LED_STRIP_SPI_FRAME_SK9822_LED_BRIGHTNESS_BITS (5) ///< Number of bits used to describe the brightness of the LED
+
 #define LED_STRIP_SPI_BUFFER_SIZE(N_PIXEL) (\
         LED_STRIP_SPI_FRAME_SK9822_START_SIZE + \
         LED_STRIP_SPI_FRAME_SK9822_LEDS_SIZE(N_PIXEL)  + \
@@ -80,9 +82,10 @@ esp_err_t led_strip_spi_sk9822_buf_init(led_strip_spi_t *strip);
  * @param[in] strip LED strip descriptor.
  * @param[in] num Index of the LED pixel (zero-based).
  * @param[in] color The color to set.
+ * @param[in] brightness The brightness to set, [0:100].
  * @return `ESP_OK` on success.
  */
-esp_err_t led_strip_spi_set_pixel_sk9822(led_strip_spi_t *strip, size_t num, rgb_t color);
+esp_err_t led_strip_spi_set_pixel_sk9822(led_strip_spi_t *strip, size_t num, rgb_t color, uint8_t brightness);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I've left the original API intact and added new functions that take a brightness value.
Brightness is defined as a value in the range 0-100, where the hardware specific driver then maps this to the actual range.