### PR TITLE
Parameters available in earlier version of ESP-IDF

### DIFF
--- a/components/led_strip/led_strip.c
+++ b/components/led_strip/led_strip.c
@@ -218,7 +218,7 @@ esp_err_t led_strip_init(led_strip_t *strip)
     }
     CHECK(rmt_translator_init(config.channel, f));
 #ifdef LED_STRIP_BRIGHTNESS
-    // No support for translator context prior to ESP-IDF 4.4
+    // No support for translator context prior to ESP-IDF 4.3
     CHECK(rmt_translator_set_context(config.channel, strip));
 #endif
 

--- a/components/led_strip/led_strip.h
+++ b/components/led_strip/led_strip.h
@@ -67,7 +67,7 @@ typedef struct
     bool is_rgbw;          ///< true for RGBW strips
 #ifdef LED_STRIP_BRIGHTNESS
     uint8_t brightness;    ///< Brightness 0..255, call ::led_strip_flush() after change.
-                           ///< Supported only for ESP-IDF version >= 4.4
+                           ///< Supported only for ESP-IDF version >= 4.3
 #endif
     size_t length;         ///< Number of LEDs in strip
     gpio_num_t gpio;       ///< Data GPIO pin

--- a/components/led_strip/led_strip.h
+++ b/components/led_strip/led_strip.h
@@ -44,7 +44,7 @@
 extern "C" {
 #endif
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)
 #define LED_STRIP_BRIGHTNESS 1
 #endif
 

--- a/components/mhz19b/mhz19b.c
+++ b/components/mhz19b/mhz19b.c
@@ -62,7 +62,7 @@ esp_err_t mhz19b_init(mhz19b_dev_t *dev, uart_port_t uart_port, gpio_num_t tx_gp
         .parity    = UART_PARITY_DISABLE,
         .stop_bits = UART_STOP_BITS_1,
         .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)
         .source_clk = UART_SCLK_APB,
 #endif
     };


### PR DESCRIPTION
The ESP-IDF version compatibility condition is referencing the wrong version. The struct parameters exist since v4.3.0, not 4.4.0. This PR fixes errors that otherwise arise from the parameters being undefined when using the libraries with ESP-IDF v4.3.0+.

For reference, you can see the parameters available in the docs:
- https://docs.espressif.com/projects/esp-idf/en/v4.3/esp32/api-reference/peripherals/uart.html#_CPPv413uart_config_t
- https://docs.espressif.com/projects/esp-idf/en/v4.3/esp32/api-reference/peripherals/rmt.html?highlight=rmt_translator_set_context#_CPPv426rmt_translator_set_context13rmt_channel_tPv

Tested the LED strip library working as it should.