### PR TITLE
ci: remove workaround for wrong CA bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,9 +164,6 @@ jobs:
           for i in $(ls -d *); do
             if [ ! -e "${__PROJECT_EXAMPLE_DIR}/${i}/${IGNORE_FILE}" ]; then
               cd "${__PROJECT_EXAMPLE_DIR}/${i}"
-              # FIXME Remove this workaround when esp-idf issue #7621 will be fixed
-              echo "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n" >> sdkconfig.defaults
-              echo "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n" >> sdkconfig.defaults
               echo "Building ${i}..."
               idf.py --ccache build
             fi
@@ -332,9 +329,6 @@ jobs:
           for i in $(ls -d *); do
             if [ ! -e "${__PROJECT_EXAMPLE_DIR}/${i}/${IGNORE_FILE}" ]; then
               cd "${__PROJECT_EXAMPLE_DIR}/${i}"
-              # FIXME Remove this workaround when esp-idf issue #7621 will be fixed
-              echo "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n" >> sdkconfig.defaults
-              echo "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n" >> sdkconfig.defaults
               echo "Building ${i}..."
               idf.py --ccache build
             fi
@@ -372,9 +366,6 @@ jobs:
             if [ ! -e "${__PROJECT_EXAMPLE_DIR}/${i}/${IGNORE_FILE}" ]; then
               cd "${__PROJECT_EXAMPLE_DIR}/${i}"
               echo "Building ${i}..."
-              # FIXME Remove this workaround when esp-idf issue #7621 will be fixed
-              echo "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n" >> sdkconfig.defaults
-              echo "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n" >> sdkconfig.defaults
               make defconfig
               make -j$(nproc)
             fi
@@ -918,9 +909,6 @@ jobs:
             if [ ! -e "${__PROJECT_EXAMPLE_DIR}/${i}/${IGNORE_FILE}" ]; then
               cd "${__PROJECT_EXAMPLE_DIR}/${i}"
               echo "Building ${i}..."
-              # FIXME Remove this workaround when esp-idf issue #7621 will be fixed
-              echo "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n" >> sdkconfig.defaults
-              echo "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n" >> sdkconfig.defaults
               idf.py --ccache build
             fi
           done
@@ -1027,9 +1015,6 @@ jobs:
             if [ ! -e "${__PROJECT_EXAMPLE_DIR}/${i}/${IGNORE_FILE}" ]; then
               cd "${__PROJECT_EXAMPLE_DIR}/${i}"
               echo "Building ${i}..."
-              # FIXME Remove this workaround when esp-idf issue #7621 will be fixed
-              echo "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n" >> sdkconfig.defaults
-              echo "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n" >> sdkconfig.defaults
               idf.py --ccache build
             fi
           done


### PR DESCRIPTION
fixed in 4.2, 4.3, and master

https://github.com/espressif/esp-idf/issues/7631#issuecomment-948445140

fixes #251