### PR TITLE
DS3231: set & get aging offset register

### DIFF
--- a/components/ds3231/ds3231.c
+++ b/components/ds3231/ds3231.c
@@ -423,7 +423,10 @@ esp_err_t ds3231_get_time(i2c_dev_t *dev, struct tm *time)
 }
 
 
-esp_err_t ds3231_set_aging_offset(i2c_dev_t *dev, int8_t age) {
+esp_err_t ds3231_set_aging_offset(i2c_dev_t *dev, int8_t age)
+{
+    CHECK_ARG(dev);
+
     uint8_t age_u8 = (uint8_t) age;
 
     I2C_DEV_TAKE_MUTEX(dev);
@@ -442,8 +445,9 @@ esp_err_t ds3231_set_aging_offset(i2c_dev_t *dev, int8_t age) {
 }
 
 
-esp_err_t ds3231_get_aging_offset(i2c_dev_t *dev, int8_t *age) {
-    CHECK_ARG(age);
+esp_err_t ds3231_get_aging_offset(i2c_dev_t *dev, int8_t *age)
+{
+    CHECK_ARG(dev && age);
 
     uint8_t age_u8;
 

--- a/components/ds3231/ds3231.c
+++ b/components/ds3231/ds3231.c
@@ -421,3 +421,37 @@ esp_err_t ds3231_get_time(i2c_dev_t *dev, struct tm *time)
 
     return ESP_OK;
 }
+
+
+esp_err_t ds3231_set_aging_offset(i2c_dev_t *dev, int8_t age) {
+    uint8_t age_u8 = (uint8_t) age;
+
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, i2c_dev_write_reg(dev, DS3231_ADDR_AGING, &age_u8, sizeof(uint8_t)));
+
+    /**
+     * To see the effects of the aging register on the 32kHz output
+     * frequency immediately, a manual conversion should be started
+     * after each aging register change.
+     */
+    I2C_DEV_CHECK(dev, ds3231_set_flag(dev, DS3231_ADDR_CONTROL, DS3231_CTRL_TEMPCONV, DS3231_SET));
+
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    return ESP_OK;
+}
+
+
+esp_err_t ds3231_get_aging_offset(i2c_dev_t *dev, int8_t *age) {
+    CHECK_ARG(age);
+
+    uint8_t age_u8;
+
+    I2C_DEV_TAKE_MUTEX(dev);
+    I2C_DEV_CHECK(dev, i2c_dev_read_reg(dev, DS3231_ADDR_AGING, &age_u8, sizeof(uint8_t)));
+    I2C_DEV_GIVE_MUTEX(dev);
+
+    *age = (int8_t) age_u8;
+
+    return ESP_OK;
+}

--- a/components/ds3231/ds3231.h
+++ b/components/ds3231/ds3231.h
@@ -306,6 +306,36 @@ esp_err_t ds3231_get_temp_integer(i2c_dev_t *dev, int8_t *temp);
  */
 esp_err_t ds3231_get_temp_float(i2c_dev_t *dev, float *temp);
 
+
+/**
+ * @brief Set the aging offset register to a new value.
+ *
+ * Positive aging values add capacitance to the array,
+ * slowing the oscillator frequency. Negative values remove
+ * capacitance from the array, increasing the oscillator
+ * frequency.
+ *
+ * **Supported only by DS3231**
+ *
+ * @param dev Device descriptor
+ * @param age Aging offset (in range [-128, 127]) to be set
+ * @return ESP_OK to indicate success
+ */
+esp_err_t ds3231_set_aging_offset(i2c_dev_t *dev, int8_t age);
+
+
+/**
+ * @brief Get the aging offset register.
+ *
+ * **Supported only by DS3231**
+ *
+ * @param dev Device descriptor
+ * @param[out] age Aging offset in range [-128, 127]
+ * @return ESP_OK to indicate success
+ */
+esp_err_t ds3231_get_aging_offset(i2c_dev_t *dev, int8_t *age);
+
+
 #ifdef	__cplusplus
 }
 #endif


### PR DESCRIPTION
I've extended the ds3231 module to set and get the aging offset register of an RTC.