### PR TITLE
Bugfix: Fix pointer arithmetic for led_strip_spi for esp8266

### DIFF
--- a/components/led_strip_spi/led_strip_spi.c
+++ b/components/led_strip_spi/led_strip_spi.c
@@ -290,7 +290,7 @@ static esp_err_t led_strip_spi_flush_esp8266(led_strip_spi_t *strip)
 
     for (int i = 0; i < mosi_buffer_block_size; i++) {
         trans.bits.mosi = ESP8266_SPI_MAX_DATA_LENGTH * 8; // bits, not bytes
-        trans.mosi = strip->buf + ESP8266_SPI_MAX_DATA_LENGTH * i / sizeof(uint32_t);
+        trans.mosi = strip->buf + ESP8266_SPI_MAX_DATA_LENGTH * i;
         err = spi_trans(HSPI_HOST, &trans);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "spi_trans(): %s", esp_err_to_name(err));
@@ -299,7 +299,7 @@ static esp_err_t led_strip_spi_flush_esp8266(led_strip_spi_t *strip)
     }
     if (mosi_buffer_block_size_mod > 0) {
         trans.bits.mosi = mosi_buffer_block_size_mod * 8; // bits, not bytes
-        trans.mosi = strip->buf + ESP8266_SPI_MAX_DATA_LENGTH * mosi_buffer_block_size / sizeof(uint32_t);
+        trans.mosi = strip->buf + ESP8266_SPI_MAX_DATA_LENGTH * mosi_buffer_block_size;
         err = spi_trans(HSPI_HOST, &trans);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "spi_trans(): %s", esp_err_to_name(err));


### PR DESCRIPTION
The current led_strip_spi has incorrect pointer arithmetic for determining the starting memory address for each chunk, which this PR fixes.

Reproduction case: 
- ESP8266 with an led strip longer than 16 LEDs
- Set 1 LED to be a distinct colour from all others (i.e. red)
- Move the position of this distinct LED through all available positions

Symptom: Multiple LEDs will become red, or sometimes none, depending on the position of the LED. The symptom is consistent.

Cause: The SPI chunk sending code incorrectly calculates the address of subsequent chunks, because `i` is divided by `sizeof(uint32)`, but `strip->buf` is a void pointer, so addition to the address should be calculated in bytes.
This results in SPI sending each subsequent chunk starting from 16 bytes after the previous start instead of 64.