### PR TITLE
led_strip_spi: fix "initialized field overwritten" error

### DIFF
--- a/components/led_strip_spi/CMakeLists.txt
+++ b/components/led_strip_spi/CMakeLists.txt
@@ -9,3 +9,4 @@ idf_component_register(
     INCLUDE_DIRS .
     REQUIRES ${req}
 )
+target_compile_options(${COMPONENT_LIB} PRIVATE -Werror=override-init)

--- a/components/led_strip_spi/led_strip_spi.c
+++ b/components/led_strip_spi/led_strip_spi.c
@@ -84,10 +84,6 @@ static esp_err_t led_strip_spi_init_esp32(led_strip_spi_t *strip)
         .quadhd_io_num = -1,
         .quadwp_io_num = -1,
 #if ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(4, 3, 2)
-        .data0_io_num = -1,
-        .data1_io_num = -1,
-        .data2_io_num = -1,
-        .data3_io_num = -1,
         .data4_io_num = -1,
         .data5_io_num = -1,
         .data6_io_num = -1,


### PR DESCRIPTION
error: initialized field overwritten [-Werror=override-init]
         .data0_io_num = -1,

`data0_io_num` is a member of union (the other member is mosi_io_num),
and should not be initilized when `mosi_io_num` is initilized.