### PR TITLE
ci: continue jobs even when a job in matrix fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
     if: ${{ needs.pre_build.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         target:
           - esp32
@@ -166,6 +167,7 @@ jobs:
     if: ${{ needs.pre_build.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         build_method:
           - idf
@@ -364,6 +366,7 @@ jobs:
     needs: pre_build
     if: ${{ needs.pre_build.outputs.should_skip != 'true' }}
     strategy:
+      fail-fast: false
       matrix:
         build_method:
 
@@ -486,6 +489,7 @@ jobs:
     needs: pre_build
     if: ${{ needs.pre_build.outputs.should_skip != 'true' }}
     strategy:
+      fail-fast: false
       matrix:
         build_method:
 
@@ -650,6 +654,7 @@ jobs:
     needs: pre_build
     if: ${{ needs.pre_build.outputs.should_skip != 'true' }}
     strategy:
+      fail-fast: false
       matrix:
         build_method:
           - idf
@@ -754,6 +759,7 @@ jobs:
     needs: pre_build
     if: ${{ needs.pre_build.outputs.should_skip != 'true' }}
     strategy:
+      fail-fast: false
       matrix:
         build_method:
           - idf


### PR DESCRIPTION
by default, fail-fast is true. this means when one job in a matrix fails,
all other jobs in the matrix are canceled. this is not useful when you
want to know which job, or which combination of target, build_method,
and version, is failing. an example is #328.

https://github.com/UncleRus/esp-idf-lib/pull/328

see Handling failures at:
https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures