### PR TITLE
ci: trigger CI tests when "Label PR" completes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,12 @@
 ---
 name: Build examples
 on:
-  pull_request:
+  workflow_run:
+    workflows:
+      - Label PR
     types:
-      - labeled
-      - synchronize
+      - completed
 
-  # include workflow_dispatch to enable manual trigger from Web UI.
-  workflow_dispatch:
 jobs:
   pre_build:
 
@@ -27,21 +26,13 @@ jobs:
           script: |
             console.log(JSON.stringify(context, null, 2))
             let should_skip = false;
+            let labels = context.payload.workflow_run.pull_requests[0].labels.map(label => { return label.name });
 
-            switch(context.payload.action) {
-              // when the added label is not "area:components", skip
-              case "labeled":
-                if (context.payload.label.name != "area:components" && context.payload.label.name != "area:ci") {
-                  should_skip = true;
-                }
-                break;
-              // when the PR branch is updated, but "area:components" label is not found, skip
-              case "synchronize":
-                let labels = context.payload.pull_request.labels.map(label => { return label.name });
-                if (!labels.includes("area:components") && !labels.includes("area:ci")) {
-                  should_skip = true;
-                }
-                break;
+            if (!labels.includes("area:components") {
+              should_skip = true;
+            }
+            if (labels.includes("area:ci") {
+              should_skip = false;
             }
             return should_skip;
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,10 +1,11 @@
 ---
 name: "Build the documentation"
 on:
-  pull_request:
+  workflow_run:
+    workflows:
+      - Label PR
     types:
-      - labeled
-      - synchronize
+      - completed
 
 jobs:
   pre_build:
@@ -19,19 +20,13 @@ jobs:
           script: |
             console.log(JSON.stringify(context, null, 2))
             let should_skip = false;
+            let labels = context.payload.workflow_run.pull_requests[0].labels.map(label => { return label.name });
 
-            switch(context.payload.action) {
-              case "labeled":
-                if (context.payload.label.name != "area:docs" && context.payload.label.name != "area:ci") {
-                  should_skip = true;
-                }
-                break;
-              case "synchronize":
-                let labels = context.payload.pull_request.labels.map(label => { return label.name });
-                if (!labels.includes("area:docs") && !labels.includes("area:ci")) {
-                  should_skip = true;
-                }
-                break;
+            if (!labels.includes("area:docs") {
+              should_skip = true;
+            }
+            if (labels.includes("area:ci") {
+              should_skip = false;
             }
             return should_skip;
   docs:

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,10 +1,12 @@
 ---
 name: Metadata
 on:
-  pull_request:
+  workflow_run:
+    workflows:
+      - Label PR
     types:
-      - labeled
-      - synchronize
+      - completed
+
 jobs:
   pre_build:
     runs-on: ubuntu-latest
@@ -18,19 +20,13 @@ jobs:
           script: |
             console.log(JSON.stringify(context, null, 2))
             let should_skip = false;
+            let labels = context.payload.workflow_run.pull_requests[0].labels.map(label => { return label.name });
 
-            switch(context.payload.action) {
-              case "labeled":
-                if (context.payload.label.name != "area:components" && context.payload.label.name != "area:ci") {
-                  should_skip = true;
-                }
-                break;
-              case "synchronize":
-                let labels = context.payload.pull_request.labels.map(label => { return label.name });
-                if (!labels.includes("area:components") && !labels.includes("are:ci")) {
-                  should_skip = true;
-                }
-                break;
+            if (!labels.includes("area:components") {
+              should_skip = true;
+            }
+            if (labels.includes("area:ci") {
+              should_skip = false;
             }
             return should_skip;
   test:


### PR DESCRIPTION
when a labeler.yml add labels to a PR, that does not trigger other
workflows to prevent accidental recursive workflow runs. that means,
with the old implementation, when a member of the repository manually
add labels to a PR, all CI tests run as intended. however, when GitHub
Action bot (the workflow to label PRs) add labels, the `labeled` event
type will not trigger other CI tests.

https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

A workaround is to use Personal Access Token, as suggested the link
above. However, i do not like Personal Access Token because the token
represents a person, and the token must be updated if you follow the
advice from GitHub (they don't like a token without expiration).

instead, use workflow_run, which can invoke other workflows without
Personal Access Token. workflow_run limits the number of chained
workflows, 3 at max, which is enought for now.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run