### PR TITLE
ci: workaround empty pull_requests in workflow_run event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,14 +19,37 @@ jobs:
     outputs:
       should_skip: ${{ steps.skip_check.outputs.result }}
     steps:
+      - name: Download the PR number from the triggering workflow as an artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: pr_number
+
+      - name: Export the number
+        run: |
+          ls -al
+          cat pr_number.txt
+          PR_NUMBER=`cat pr_number.txt`
+          echo "PR_NUMBER=${PR_NUMBER}" >> ${GITHUB_ENV}
+
       - id: skip_check
         uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
+            console.log("context");
             console.log(JSON.stringify(context, null, 2));
             let should_skip = false;
-            let labels = context.payload.workflow_run.pull_requests[0].labels.map(label => { return label.name });
+            let pr_number = parseInt(process.env.PR_NUMBER);
+
+            pull_request = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr_number,
+            });
+            console.log("pull_request");
+            console.log(JSON.stringify(pull_request, null, 2));
+
+            let labels = pull_request.labels.map(label => { return label.name });
 
             if (!labels.includes("area:components")) {
               should_skip = true;

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,14 +13,37 @@ jobs:
     outputs:
       should_skip: ${{ steps.skip_check.outputs.result }}
     steps:
+      - name: Download the PR number from the triggering workflow as an artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: pr_number
+
+      - name: Export the number
+        run: |
+          ls -al
+          cat pr_number.txt
+          PR_NUMBER=`cat pr_number.txt`
+          echo "PR_NUMBER=${PR_NUMBER}" >> ${GITHUB_ENV}
+
       - id: skip_check
         uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
+            console.log("context");
             console.log(JSON.stringify(context, null, 2));
             let should_skip = false;
-            let labels = context.payload.workflow_run.pull_requests[0].labels.map(label => { return label.name });
+            let pr_number = parseInt(process.env.PR_NUMBER);
+
+            pull_request = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr_number,
+            });
+            console.log("pull_request");
+            console.log(JSON.stringify(pull_request, null, 2));
+
+            let labels = pull_request.labels.map(label => { return label.name });
 
             if (!labels.includes("area:docs")) {
               should_skip = true;

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -31,3 +31,21 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           config-path: .github/labeler.yml
+
+      - name: Save the PR number for other workflows triggered by this workflow
+        # pass the PR number to other workflows.
+        #
+        # background: workflows triggered by workflow_run get an event context.
+        # the context, somehow, does not include pull_requests object (I don't
+        # know why GitHub does not include it). that means the triggered
+        # workflow has no way to know the PR number. workaround the issue by
+        # uploading the PR number as an artifact.
+        run: |
+          echo "${{ github.event.number }}" > pr_number.txt
+
+      - name: Upload the PR number as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          if-no-files-found: error

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -13,14 +13,37 @@ jobs:
     outputs:
       should_skip: ${{ steps.skip_check.outputs.result }}
     steps:
+      - name: Download the PR number from the triggering workflow as an artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: pr_number
+
+      - name: Export the number
+        run: |
+          ls -al
+          cat pr_number.txt
+          PR_NUMBER=`cat pr_number.txt`
+          echo "PR_NUMBER=${PR_NUMBER}" >> ${GITHUB_ENV}
+
       - id: skip_check
         uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
+            console.log("context");
             console.log(JSON.stringify(context, null, 2));
             let should_skip = false;
-            let labels = context.payload.workflow_run.pull_requests[0].labels.map(label => { return label.name });
+            let pr_number = parseInt(process.env.PR_NUMBER);
+
+            pull_request = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr_number,
+            });
+            console.log("pull_request");
+            console.log(JSON.stringify(pull_request, null, 2));
+
+            let labels = pull_request.labels.map(label => { return label.name });
 
             if (!labels.includes("area:components")) {
               should_skip = true;


### PR DESCRIPTION
the context other workflows triggered by workflow_run does not include
pull_requests objects.

pass the PR number from the triggering workflow, and get the PR using
an API, extract a list of labels from the response.