### PR TITLE
ci: revert to pull_request-based CI 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,10 @@
 ---
 name: Build examples
 on:
-  workflow_run:
-    workflows:
-      - Label PR
+  pull_request:
     types:
-      - completed
+      - labeled
+      - synchronize
 
 jobs:
   pre_build:
@@ -19,23 +18,6 @@ jobs:
     outputs:
       should_skip: ${{ steps.skip_check.outputs.result }}
     steps:
-      - name: Download the PR number from the triggering workflow as an artifact
-        # XXX actions/download-artifact does not work here.
-        # see the rationale at: https://github.com/dawidd6/action-download-artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: labeler.yml
-          run_id: ${{ github.event.workflow_run.id }}
-          name: pr_number
-
-      - name: Export the number
-        run: |
-          ls -al
-          cat pr_number.txt
-          PR_NUMBER=`cat pr_number.txt`
-          echo "PR_NUMBER=${PR_NUMBER}" >> ${GITHUB_ENV}
-
       - id: skip_check
         uses: actions/github-script@v6
         with:
@@ -44,24 +26,26 @@ jobs:
             console.log("context");
             console.log(JSON.stringify(context, null, 2));
             let should_skip = false;
-            let pr_number = parseInt(process.env.PR_NUMBER);
 
-            pull_request = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr_number,
-            });
-            console.log("pull_request");
-            console.log(JSON.stringify(pull_request, null, 2));
-
-            let labels = pull_request.data.labels.map(label => { return label.name });
-
-            if (!labels.includes("area:components")) {
-              should_skip = true;
-            }
-            if (labels.includes("area:ci")) {
-              should_skip = false;
-            }
+            switch(context.payload.action) {
+              case "labeled":
+                if (context.payload.label.name != "area:components") {
+                  should_skip = true;
+                }
+                if (context.payload.label.name == "area:ci") {
+                  should_skip = false;
+                }
+                break;
+              case "synchronize":
+                let labels = context.payload.pull_request.labels.map(label => { return label.name });
+                if (!labels.includes("area:components")) {
+                  should_skip = true;
+                }
+                if (labels.includes("area:ci")) {
+                  should_skip = false;
+                }
+                break;
+              }
             return should_skip;
 
   # XXX create multiple jobs for major versions

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,11 +1,10 @@
 ---
 name: "Build the documentation"
 on:
-  workflow_run:
-    workflows:
-      - Label PR
+  pull_request:
     types:
-      - completed
+      - labeled
+      - synchronize
 
 jobs:
   pre_build:
@@ -13,23 +12,6 @@ jobs:
     outputs:
       should_skip: ${{ steps.skip_check.outputs.result }}
     steps:
-      - name: Download the PR number from the triggering workflow as an artifact
-        # XXX actions/download-artifact does not work here.
-        # see the rationale at: https://github.com/dawidd6/action-download-artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: labeler.yml
-          run_id: ${{ github.event.workflow_run.id }}
-          name: pr_number
-
-      - name: Export the number
-        run: |
-          ls -al
-          cat pr_number.txt
-          PR_NUMBER=`cat pr_number.txt`
-          echo "PR_NUMBER=${PR_NUMBER}" >> ${GITHUB_ENV}
-
       - id: skip_check
         uses: actions/github-script@v6
         with:
@@ -38,24 +20,26 @@ jobs:
             console.log("context");
             console.log(JSON.stringify(context, null, 2));
             let should_skip = false;
-            let pr_number = parseInt(process.env.PR_NUMBER);
 
-            pull_request = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr_number,
-            });
-            console.log("pull_request");
-            console.log(JSON.stringify(pull_request, null, 2));
-
-            let labels = pull_request.data.labels.map(label => { return label.name });
-
-            if (!labels.includes("area:docs")) {
-              should_skip = true;
-            }
-            if (labels.includes("area:ci")) {
-              should_skip = false;
-            }
+            switch(context.payload.action) {
+              case "labeled":
+                if (context.payload.label.name != "area:docs") {
+                  should_skip = true;
+                }
+                if (context.payload.label.name == "area:ci") {
+                  should_skip = false;
+                }
+                break;
+              case "synchronize":
+                let labels = context.payload.pull_request.labels.map(label => { return label.name });
+                if (!labels.includes("area:docs")) {
+                  should_skip = true;
+                }
+                if (labels.includes("area:ci")) {
+                  should_skip = false;
+                }
+                break;
+              }
             return should_skip;
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -31,21 +31,3 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           config-path: .github/labeler.yml
-
-      - name: Save the PR number for other workflows triggered by this workflow
-        # pass the PR number to other workflows.
-        #
-        # background: workflows triggered by workflow_run get an event context.
-        # the context, somehow, does not include pull_requests object (I don't
-        # know why GitHub does not include it). that means the triggered
-        # workflow has no way to know the PR number. workaround the issue by
-        # uploading the PR number as an artifact.
-        run: |
-          echo "${{ github.event.number }}" > pr_number.txt
-
-      - name: Upload the PR number as an artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: pr_number
-          path: pr_number.txt
-          if-no-files-found: error

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -25,9 +25,20 @@ permissions:
 jobs:
   labeler:
     name: Labeler
+    if: ${{ secrets.LABELER_TOKEN == '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: fuxingloh/multi-labeler@v1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
+          config-path: .github/labeler.yml
+
+  labeler_with_personal_access_token:
+    name: Labeler with Personal Access Token
+    if: ${{ secrets.LABELER_TOKEN != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fuxingloh/multi-labeler@v1
+        with:
+          github-token: ${{secrets.LABELER_TOKEN}}
           config-path: .github/labeler.yml

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,11 +1,10 @@
 ---
 name: Metadata
 on:
-  workflow_run:
-    workflows:
-      - Label PR
+  pull_request:
     types:
-      - completed
+      - labeled
+      - synchronize
 
 jobs:
   pre_build:
@@ -13,23 +12,6 @@ jobs:
     outputs:
       should_skip: ${{ steps.skip_check.outputs.result }}
     steps:
-      - name: Download the PR number from the triggering workflow as an artifact
-        # XXX actions/download-artifact does not work here.
-        # see the rationale at: https://github.com/dawidd6/action-download-artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: labeler.yml
-          run_id: ${{ github.event.workflow_run.id }}
-          name: pr_number
-
-      - name: Export the number
-        run: |
-          ls -al
-          cat pr_number.txt
-          PR_NUMBER=`cat pr_number.txt`
-          echo "PR_NUMBER=${PR_NUMBER}" >> ${GITHUB_ENV}
-
       - id: skip_check
         uses: actions/github-script@v6
         with:
@@ -38,24 +20,26 @@ jobs:
             console.log("context");
             console.log(JSON.stringify(context, null, 2));
             let should_skip = false;
-            let pr_number = parseInt(process.env.PR_NUMBER);
 
-            pull_request = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr_number,
-            });
-            console.log("pull_request");
-            console.log(JSON.stringify(pull_request, null, 2));
-
-            let labels = pull_request.data.labels.map(label => { return label.name });
-
-            if (!labels.includes("area:components")) {
-              should_skip = true;
-            }
-            if (labels.includes("area:ci")) {
-              should_skip = false;
-            }
+            switch(context.payload.action) {
+              case "labeled":
+                if (context.payload.label.name != "area:components") {
+                  should_skip = true;
+                }
+                if (context.payload.label.name == "area:ci") {
+                  should_skip = false;
+                }
+                break;
+              case "synchronize":
+                let labels = context.payload.pull_request.labels.map(label => { return label.name });
+                if (!labels.includes("area:components")) {
+                  should_skip = true;
+                }
+                if (labels.includes("area:ci")) {
+                  should_skip = false;
+                }
+                break;
+              }
             return should_skip;
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
this PR revert to `pull_request`-based CI as I originally wrote. the implementation in `master` branch does not behave like the previous one.

the PR supports with or without Personal Access Token. If the PAT is defined (`LABELER_TOKEN`), automatically assigned labels trigger CI tests. If not defined, fallback to `GITHUB_TOKEN`, and manual labeling is necessary to trigger CI tests.