### PR TITLE
i2cdev: Fix i2c param config and driver install order for esp32 target

### DIFF
--- a/components/i2cdev/i2cdev.c
+++ b/components/i2cdev/i2cdev.c
@@ -205,9 +205,9 @@ static esp_err_t i2c_setup_port(const i2c_dev_t *dev)
             states[dev->port].installed = false;
         }
 #if HELPER_TARGET_IS_ESP32
-        if ((res = i2c_param_config(dev->port, &temp)) != ESP_OK)
-            return res;
         if ((res = i2c_driver_install(dev->port, temp.mode, 0, 0, 0)) != ESP_OK)
+            return res;
+        if ((res = i2c_param_config(dev->port, &temp)) != ESP_OK)
             return res;
 #endif
 #if HELPER_TARGET_IS_ESP8266

--- a/components/i2cdev/i2cdev.c
+++ b/components/i2cdev/i2cdev.c
@@ -205,10 +205,18 @@ static esp_err_t i2c_setup_port(const i2c_dev_t *dev)
             states[dev->port].installed = false;
         }
 #if HELPER_TARGET_IS_ESP32
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
+        // See https://github.com/espressif/esp-idf/issues/10163
         if ((res = i2c_driver_install(dev->port, temp.mode, 0, 0, 0)) != ESP_OK)
             return res;
         if ((res = i2c_param_config(dev->port, &temp)) != ESP_OK)
             return res;
+#else
+        if ((res = i2c_param_config(dev->port, &temp)) != ESP_OK)
+            return res;
+        if ((res = i2c_driver_install(dev->port, temp.mode, 0, 0, 0)) != ESP_OK)
+            return res;
+#endif
 #endif
 #if HELPER_TARGET_IS_ESP8266
         // Clock Stretch time, depending on CPU frequency


### PR DESCRIPTION
i2c_driver_install() needs to be called before i2c_param_config(). This fixes panic reported on [1].

Link: [1] https://github.com/espressif/esp-idf/issues/10163
Signed-off-by: Axel Lin <axel.lin@ingics.com>