### PR TITLE
improved example for ads130e08

### DIFF
--- a/examples/ads130e08/default/main/main.c
+++ b/examples/ads130e08/default/main/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <freertos/FreeRTOS.h>
+#include "freertos/semphr.h"
 #include <freertos/task.h>
 #include <esp_log.h>
 #include <esp_err.h>


### PR DESCRIPTION
Improved the example for ads130e08 library, allowing the data to be read continuously with the use of a binary semaphore.