### PR TITLE
added esp32s3 support for ads130e08

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ or [GitLab examples](https://gitlab.com/UncleRus/esp-idf-lib/tree/master/example
 | Component                | Description                                                                      | License | Supported on       | Thread safety
 |--------------------------|----------------------------------------------------------------------------------|---------|--------------------|--------------
 | **ads111x**              | Driver for ADS1113/ADS1114/ADS1115 and ADS1013/ADS1014/ADS1015 I2C ADC           | BSD-3   | `esp32`, `esp8266`, `esp32s2`, `esp32c3` | Yes
-| **ads130e08**            | Driver for ADS130E08 ADC                                                         | MIT     | `esp32`            | Yes
+| **ads130e08**            | Driver for ADS130E08 ADC                                                         | MIT     | `esp32`, `esp32s3` | Yes
 | **hx711**                | Driver for HX711 24-bit ADC for weigh scales                                     | BSD-3   | `esp32`, `esp8266`, `esp32s2`, `esp32c3` | No
 | **mcp342x**              | Driver for 18-Bit, delta-sigma ADC MCP3426/MCP3427/MCP3428                       | BSD-3   | `esp32`, `esp8266`, `esp32s2`, `esp32c3` | Yes
 | **mcp4725**              | Driver for 12-bit DAC MCP4725                                                    | BSD-3   | `esp32`, `esp8266`, `esp32s2`, `esp32c3` | Yes

--- a/components/ads130e08/.eil.yml
+++ b/components/ads130e08/.eil.yml
@@ -11,6 +11,7 @@ components:
     thread_safe: yes
     targets:
       - name: esp32
+      - name: esp32s3
     licenses:
       - name: MIT
     copyrights:

--- a/examples/ads130e08/default/README.md
+++ b/examples/ads130e08/default/README.md
@@ -18,7 +18,7 @@ Connect `MOSI`, `MISO`, `SCLK`, `CS` and `INT` pins to the following pins:
 | `CONFIG_EXAMPLE_CS_GPIO` | GPIO number for `CS` | "5" for `esp32` |
 | `CONFIG_EXAMPLE_INT_GPIO` | GPIO number for `INT` | "26" for `esp32` |
 
-The driver was only tested in ESP32, but should also work on other ESP boards.
+The driver was tested in ESP32 and ESP32S3, but should also work on other ESP boards.
 
 ## Notes
 


### PR DESCRIPTION
Implementation of ads130e08 driver validated on ESP32S3 board.