### PR TITLE
Encoder: properly configure pin when using BTN_PRESSED_LEVEL = 1

### DIFF
--- a/components/encoder/encoder.c
+++ b/components/encoder/encoder.c
@@ -204,7 +204,13 @@ esp_err_t rotary_encoder_add(rotary_encoder_t *re)
     gpio_config_t io_conf;
     memset(&io_conf, 0, sizeof(gpio_config_t));
     io_conf.mode = GPIO_MODE_INPUT;
-    io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+    if (BTN_PRESSED_LEVEL == 0) {
+        io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+        io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    } else {
+        io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+        io_conf.pull_down_en = GPIO_PULLDOWN_ENABLE;
+    }
     io_conf.intr_type = GPIO_INTR_DISABLE;
     io_conf.pin_bit_mask = GPIO_BIT(re->pin_a) | GPIO_BIT(re->pin_b);
     if (re->pin_btn < GPIO_NUM_MAX)


### PR DESCRIPTION
When using BTN_PRESSED_LEVEL 1 (CONFIG_RE_BTN_PRESSED_LEVEL_1=y) the input pins should be pulled down instead of up. 

Also explicitly configured the opposite setting for clarity