### PR TITLE
Update function name in mcp23x17.c to match the one in the header

### DIFF
--- a/components/mcp23x17/mcp23x17.c
+++ b/components/mcp23x17/mcp23x17.c
@@ -320,7 +320,7 @@ esp_err_t mcp23x17_init_desc_spi(mcp23x17_t *dev, spi_host_device_t host, uint32
     return spi_bus_add_device(host, &dev->spi_cfg, &dev->spi_dev);
 }
 
-esp_err_t mcp23x17_free_desc(mcp23x17_t *dev)
+esp_err_t mcp23x17_free_desc_spi(mcp23x17_t *dev)
 {
     CHECK_ARG(dev);
 


### PR DESCRIPTION
The mcp23x17.h file defines a function called mcp23x17_free_desc_spi, but the corresponding implementation in the mcp23x17.c file referred to it as mcp23x17_free_desc.