### PR TITLE
Ensure the ODR bit is cleared before setting the INTPOL bit.

### DIFF
--- a/components/mcp23x17/mcp23x17.c
+++ b/components/mcp23x17/mcp23x17.c
@@ -359,6 +359,8 @@ esp_err_t mcp23x17_set_int_out_mode(mcp23x17_t *dev, mcp23x17_int_out_mode_t mod
     if (mode == MCP23X17_OPEN_DRAIN)
         return write_reg_bit_8(dev, REG_IOCON, true, BIT_IOCON_ODR);
 
+    // The INTPOL bit is only functional if the ODR bit is cleared.
+    write_reg_bit_8(dev, REG_IOCON, false, BIT_IOCON_ODR);
     return write_reg_bit_8(dev, REG_IOCON, mode == MCP23X17_ACTIVE_HIGH, BIT_IOCON_INTPOL);
 }
 


### PR DESCRIPTION
According to the MCP23S17 data sheet:

> The Open-Drain (ODR) control bit enables/disables the INT pin for open-drain configuration. Setting this bit overrides the INTPOL bit. The Interrupt Polarity (INTPOL) sets the polarity of the INT pin. This bit is functional only when the ODR bit is cleared, configuring the INT pin as active push-pull.

This PR proposes to clear the ODR bit if INTPOL gets set.