### PR TITLE
fix for issue #501 - comparing i2c configuration on 8266

### DIFF
--- a/components/i2cdev/i2cdev.c
+++ b/components/i2cdev/i2cdev.c
@@ -180,7 +180,9 @@ inline static bool cfg_equal(const i2c_config_t *a, const i2c_config_t *b)
 #if HELPER_TARGET_IS_ESP32
         && a->master.clk_speed == b->master.clk_speed
 #elif HELPER_TARGET_IS_ESP8266
-        && a->clk_stretch_tick == b->clk_stretch_tick
+        && ((a->clk_stretch_tick && a->clk_stretch_tick == b->clk_stretch_tick) 
+            || (!a->clk_stretch_tick && b->clk_stretch_tick == I2CDEV_MAX_STRETCH_TIME)
+        ) // see line 232
 #endif
         && a->scl_pullup_en == b->scl_pullup_en
         && a->sda_pullup_en == b->sda_pullup_en;


### PR DESCRIPTION
Fix for issue #501 

I tested it on my 8266 Development board with PCA9685 and MPU6050.

`i2c_setup_port()` stopped reconfiguring for every i2c read or write, which I believe impacts positively performance on this platform.
