### PR TITLE
fix: lsm303 ODR names and non-static scale arrays

### DIFF
--- a/components/lsm303/lsm303.c
+++ b/components/lsm303/lsm303.c
@@ -92,7 +92,7 @@
 /* accelerometer STATUS_REG_A */
 #define LSM303_ACC_STATUS_ZYXOR 0x80
 #define LSM303_ACC_STATUS_ZOR   0x40
-#define LSM303_STATUS_YOR       0x20
+#define LSM303_ACC_STATUS_YOR   0x20
 #define LSM303_ACC_STATUS_XOR   0x10
 #define LSM303_ACC_STATUS_ZYXDA 0x08
 #define LSM303_ACC_STATUS_ZDA   0x04
@@ -182,7 +182,7 @@ esp_err_t lsm303_init_desc(lsm303_t *dev, uint8_t acc_addr, uint8_t mag_addr, i2
 #endif
 
     dev->acc_mode = LSM303_ACC_MODE_NORMAL;
-    dev->acc_rate = LSM303_ODR30_10_HZ;
+    dev->acc_rate = LSM303_ODR_10_HZ;
     dev->acc_scale = LSM303_ACC_SCALE_2G;
 
     dev->mag_mode = LSM303_MAG_MODE_CONT;
@@ -348,7 +348,7 @@ esp_err_t lsm303_acc_raw_to_g(lsm303_t *dev, lsm303_acc_raw_data_t *raw, lsm303_
 {
     CHECK_ARG(dev && raw && data);
 
-    static const float lsb[][4] = {
+    const float lsb[][4] = {
         [LSM303_ACC_MODE_NORMAL] = {
             [LSM303_ACC_SCALE_2G] = 0.0039,
             [LSM303_ACC_SCALE_4G] = 0.00782,
@@ -368,7 +368,7 @@ esp_err_t lsm303_acc_raw_to_g(lsm303_t *dev, lsm303_acc_raw_data_t *raw, lsm303_
             [LSM303_ACC_SCALE_16G] = 0.18758
         },
     };
-    static const int shift[] = {
+    const int shift[] = {
         [LSM303_ACC_MODE_NORMAL] = 6,          // 10-bit
         [LSM303_ACC_MODE_HIGH_RESOLUTION] = 4, // 12-bit
         [LSM303_ACC_MODE_LOW_POWER] = 8        // 8-bit
@@ -447,7 +447,7 @@ esp_err_t lsm303_mag_raw_to_uT(lsm303_t *dev, lsm303_mag_raw_data_t *raw, lsm303
     /* gain for XY axis is different from Z axis */
     enum { GAIN_XY = 0, GAIN_Z = 1 };
     /*  { xy , z} */
-    static const float gauss_lsb[][2] = {
+    const float gauss_lsb[][2] = {
         [LSM303_MAG_GAIN_1_3] = { 1100, 980 },
         [LSM303_MAG_GAIN_1_9] = { 855, 760 },
         [LSM303_MAG_GAIN_2_5] = { 670, 600 },

--- a/components/lsm303/lsm303.c
+++ b/components/lsm303/lsm303.c
@@ -348,7 +348,7 @@ esp_err_t lsm303_acc_raw_to_g(lsm303_t *dev, lsm303_acc_raw_data_t *raw, lsm303_
 {
     CHECK_ARG(dev && raw && data);
 
-    const float lsb[][4] = {
+    static const float lsb[][4] = {
         [LSM303_ACC_MODE_NORMAL] = {
             [LSM303_ACC_SCALE_2G] = 0.0039,
             [LSM303_ACC_SCALE_4G] = 0.00782,
@@ -368,7 +368,7 @@ esp_err_t lsm303_acc_raw_to_g(lsm303_t *dev, lsm303_acc_raw_data_t *raw, lsm303_
             [LSM303_ACC_SCALE_16G] = 0.18758
         },
     };
-    const int shift[] = {
+    static const int shift[] = {
         [LSM303_ACC_MODE_NORMAL] = 6,          // 10-bit
         [LSM303_ACC_MODE_HIGH_RESOLUTION] = 4, // 12-bit
         [LSM303_ACC_MODE_LOW_POWER] = 8        // 8-bit
@@ -447,7 +447,7 @@ esp_err_t lsm303_mag_raw_to_uT(lsm303_t *dev, lsm303_mag_raw_data_t *raw, lsm303
     /* gain for XY axis is different from Z axis */
     enum { GAIN_XY = 0, GAIN_Z = 1 };
     /*  { xy , z} */
-    const float gauss_lsb[][2] = {
+    static const float gauss_lsb[][2] = {
         [LSM303_MAG_GAIN_1_3] = { 1100, 980 },
         [LSM303_MAG_GAIN_1_9] = { 855, 760 },
         [LSM303_MAG_GAIN_2_5] = { 670, 600 },

--- a/components/lsm303/lsm303.h
+++ b/components/lsm303/lsm303.h
@@ -68,16 +68,16 @@ typedef enum {
  * Accelerometer data rates
  */
 typedef enum {
-    LSM303_ODR30_POWER_DOWN = 0b0000, //!< Power-down mode
-    LSM303_ODR30_1_HZ = 0b0001,       //!< Normal / low-power mode (1 Hz)
-    LSM303_ODR30_10_HZ = 0b0010,
-    LSM303_ODR30_25_HZ = 0b0011,
-    LSM303_ODR30_50_HZ = 0b0100,
-    LSM303_ODR30_100_HZ = 0b0101,
-    LSM303_ODR30_200_HZ = 0b0110,
-    LSM303_ODR30_400_HZ = 0b0111,
-    LSM303_ODR30_1620_HZ = 0b1000,
-    LSM303_ODR30_5376_HZ = 0b1001     //!< Normal (1.344 kHz) / low-power mode (5.376 KHz)
+    LSM303_ODR_POWER_DOWN = 0b0000, //!< Power-down mode
+    LSM303_ODR_1_HZ = 0b0001,       //!< Normal / low-power mode (1 Hz)
+    LSM303_ODR_10_HZ = 0b0010,      //!< Normal / low-power mode (10 Hz)
+    LSM303_ODR_25_HZ = 0b0011,      //!< Normal / low-power mode (25 Hz)
+    LSM303_ODR_50_HZ = 0b0100,      //!< Normal / low-power mode (50 Hz)
+    LSM303_ODR_100_HZ = 0b0101,     //!< Normal / low-power mode (100 Hz)
+    LSM303_ODR_200_HZ = 0b0110,     //!< Normal / low-power mode (200 Hz)
+    LSM303_ODR_400_HZ = 0b0111,     //!< Normal / low-power mode (400 Hz)
+    LSM303_ODR_1620_HZ = 0b1000,    //!< Low-power mode (1.620 kHz)
+    LSM303_ODR_5376_HZ = 0b1001     //!< Normal (1.344 kHz) / low-power mode (5.376 KHz)
 } lsm303_acc_rate_t;
 
 /**
@@ -104,14 +104,14 @@ typedef enum {
  * Magnetometer rates
  */
 typedef enum {
-    LSM303_MAG_RATE_0_7, //!< 0.75 Hz
-    LSM303_MAG_RATE_1_5, //!< 1.5 Hz
-    LSM303_MAG_RATE_3_0, //!< 3.0 Hz
-    LSM303_MAG_RATE_7_5, //!< 7.5 Hz
-    LSM303_MAG_RATE_15,  //!< 15 Hz
-    LSM303_MAG_RATE_30,  //!< 30 Hz
-    LSM303_MAG_RATE_75,  //!< 75 Hz
-    LSM303_MAG_RATE_220  //!< 220 Hz
+    LSM303_MAG_RATE_0_75, //!< 0.75 Hz
+    LSM303_MAG_RATE_1_5,  //!< 1.5 Hz
+    LSM303_MAG_RATE_3_0,  //!< 3.0 Hz
+    LSM303_MAG_RATE_7_5,  //!< 7.5 Hz
+    LSM303_MAG_RATE_15,   //!< 15 Hz
+    LSM303_MAG_RATE_30,   //!< 30 Hz
+    LSM303_MAG_RATE_75,   //!< 75 Hz
+    LSM303_MAG_RATE_220   //!< 220 Hz
 } lsm303_mag_rate_t;
 
 /**

--- a/examples/lsm303/default/main/main.c
+++ b/examples/lsm303/default/main/main.c
@@ -22,7 +22,7 @@ void lsm303_test(void *pvParameters)
     ESP_ERROR_CHECK(lsm303_init(&lsm303));
 
     /* OPTIONAL */
-    ESP_ERROR_CHECK(lsm303_acc_set_config(&lsm303, LSM303_ACC_MODE_NORMAL, LSM303_ODR30_100_HZ, LSM303_ACC_SCALE_2G));
+    ESP_ERROR_CHECK(lsm303_acc_set_config(&lsm303, LSM303_ACC_MODE_NORMAL, LSM303_ODR_100_HZ, LSM303_ACC_SCALE_2G));
     ESP_ERROR_CHECK(lsm303_mag_set_config(&lsm303, LSM303_MAG_MODE_CONT, LSM303_MAG_RATE_15, LSM303_MAG_GAIN_1_3));
 
     while (1)


### PR DESCRIPTION
I have fixed ODR enum names and removed static specifier conversion arrays