### PR TITLE
feat: add PCA9536 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ or [GitLab examples](https://gitlab.com/UncleRus/esp-idf-lib/tree/master/example
 |--------------------------|----------------------------------------------------------------------------------|---------|--------------------|---------------|
 | **mcp23008**             | Driver for 8-bit I2C GPIO expander MCP23008                                      | BSD-3-Clause | esp32, esp8266, esp32s2, esp32c3 | yes           |
 | **mcp23x17**             | Driver for I2C/SPI 16 bit GPIO expanders MCP23017/MCP23S17                       | BSD-3-Clause | esp32, esp32s2, esp32c3 | yes           |
-| **pca9557**              | Driver for PCA9537/PCA9557/TCA9534 remote 4/8-bit I/O expanders for I2C-bus      | BSD-3-Clause | esp32, esp8266, esp32s2, esp32c3 | yes           |
+| **pca9557**              | Driver for PCA9536/PCA9537/PCA9557/TCA9534 remote 4/8-bit I/O expanders for I2C-bus | BSD-3-Clause | esp32, esp8266, esp32s2, esp32c3 | yes           |
 | **pcf8574**              | Driver for PCF8574 remote 8-bit I/O expander for I2C-bus                         | MIT     | esp32, esp8266, esp32s2, esp32c3 | yes           |
 | **pcf8575**              | Driver for PCF8575 remote 16-bit I/O expander for I2C-bus                        | MIT     | esp32, esp8266, esp32s2, esp32c3 | yes           |
 | **tca6424a**             | Driver for TCA6424A low-voltage 24-bit I2C I/O expander                          | BSD-3-Clause | esp32, esp8266, esp32s2, esp32c3 | yes           |

--- a/components/pca9557/.eil.yml
+++ b/components/pca9557/.eil.yml
@@ -1,5 +1,5 @@
 name: pca9557
-description: Driver for PCA9537/PCA9557/TCA9534 remote 4/8-bit I/O expanders for I2C-bus
+description: Driver for PCA9536/PCA9537/PCA9557/TCA9534 remote 4/8-bit I/O expanders for I2C-bus
 version: 1.0.0
 groups:
   - gpio

--- a/components/pca9557/pca9557.c
+++ b/components/pca9557/pca9557.c
@@ -28,7 +28,7 @@
 /**
  * @file pca9557.c
  *
- * ESP-IDF driver for PCA9537/PCA9557/TCA9534 remote 4/8-bit I/O expanders for I2C-bus
+ * ESP-IDF driver for PCA9536/PCA9537/PCA9557/TCA9534 remote 4/8-bit I/O expanders for I2C-bus
  *
  * Copyright (c) 2021 Ruslan V. Uss <unclerus@gmail.com>
  *
@@ -103,7 +103,7 @@ esp_err_t pca9557_init_desc(i2c_dev_t *dev, uint8_t addr, i2c_port_t port, gpio_
     CHECK_ARG(dev && (
             (addr & PCA9557_I2C_ADDR_BASE) == PCA9557_I2C_ADDR_BASE ||
             (addr & TCA9534_I2C_ADDR_BASE) == TCA9534_I2C_ADDR_BASE ||
-            addr == PCA9537_I2C_ADDR));
+            addr == PCA9537_I2C_ADDR || addr == PCA9536_I2C_ADDR));
 
     dev->port = port;
     dev->addr = addr;

--- a/components/pca9557/pca9557.h
+++ b/components/pca9557/pca9557.h
@@ -30,7 +30,7 @@
  * @defgroup pca9557 pca9557
  * @{
  *
- * ESP-IDF driver for PCA9537/PCA9557/TCA9534 remote 4/8-bit I/O expanders for I2C-bus
+ * ESP-IDF driver for PCA9536/PCA9537/PCA9557/TCA9534 remote 4/8-bit I/O expanders for I2C-bus
  *
  * Copyright (c) 2021 Ruslan V. Uss <unclerus@gmail.com>
  *
@@ -47,6 +47,7 @@
 extern "C" {
 #endif
 
+#define PCA9536_I2C_ADDR      0x41 ///< I2C address for PCA9536
 #define PCA9537_I2C_ADDR      0x49 ///< I2C address for PCA9537
 #define PCA9557_I2C_ADDR_BASE 0x18 ///< Base I2C address for PCA9557
 #define TCA9534_I2C_ADDR_BASE 0x20 ///< Base I2C address for TCA9534
@@ -129,7 +130,7 @@ esp_err_t pca9557_port_set_polarity(i2c_dev_t *dev, uint8_t pol);
  * @brief Read I/O port value
  *
  * @param dev       Pointer to I2C device descriptor
- * @param[out] val  8-bit GPIO port value for PCA9557 or 4-bit port value for PCA9537
+ * @param[out] val  8-bit GPIO port value for PCA9557 or 4-bit port value for PCA9536/PCA9537
  * @return `ESP_OK` on success
  */
 esp_err_t pca9557_port_read(i2c_dev_t *dev, uint8_t *val);
@@ -138,7 +139,7 @@ esp_err_t pca9557_port_read(i2c_dev_t *dev, uint8_t *val);
  * @brief Write value to I/O port
  *
  * @param dev     Pointer to I2C device descriptor
- * @param val     8-bit GPIO port value for PCA9557 or 4-bit port value for PCA9537
+ * @param val     8-bit GPIO port value for PCA9557 or 4-bit port value for PCA9536/PCA9537
  * @return ESP_OK on success
  */
 esp_err_t pca9557_port_write(i2c_dev_t *dev, uint8_t val);
@@ -147,7 +148,7 @@ esp_err_t pca9557_port_write(i2c_dev_t *dev, uint8_t val);
  * @brief Read I/O pin mode
  *
  * @param dev       Pointer to device descriptor
- * @param pin       Pin number, 0..7 for PCA9557, 0..3 for PC9537
+ * @param pin       Pin number, 0..7 for PCA9557, 0..3 for PCA9536/PC9537
  * @param[out] mode Pin mode
  * @return `ESP_OK` on success
  */
@@ -157,7 +158,7 @@ esp_err_t pca9557_get_mode(i2c_dev_t *dev, uint8_t pin, pca9557_mode_t *mode);
  * @brief Set I/O pin mode
  *
  * @param dev      Pointer to device descriptor
- * @param pin      Pin number, 0..7 for PCA9557, 0..3 for PC9537
+ * @param pin      Pin number, 0..7 for PCA9557, 0..3 for PCA9536/PC9537
  * @param mode     Pin mode
  * @return `ESP_OK` on success
  */
@@ -167,7 +168,7 @@ esp_err_t pca9557_set_mode(i2c_dev_t *dev, uint8_t pin, pca9557_mode_t mode);
  * @brief Read I/O pin level
  *
  * @param dev      Pointer to device descriptor
- * @param pin      Pin number, 0..7 for PCA9557, 0..3 for PC9537
+ * @param pin      Pin number, 0..7 for PCA9557, 0..3 for PCA9536/PC9537
  * @param[out] val 1 if pin currently in high state, 0 otherwise
  * @return `ESP_OK` on success
  */
@@ -179,7 +180,7 @@ esp_err_t pca9557_get_level(i2c_dev_t *dev, uint8_t pin, uint32_t *val);
  * Pin must be set up as output
  *
  * @param dev      Pointer to device descriptor
- * @param pin      Pin number, 0..7 for PCA9557, 0..3 for PC9537
+ * @param pin      Pin number, 0..7 for PCA9557, 0..3 for PCA9536/PC9537
  * @param val      Pin level. 1 - high, 0 - low
  * @return `ESP_OK` on success
  */


### PR DESCRIPTION
The `pca9557` driver works well with PCA9536 but needs its i2c address in `pca9557_init_desc`