### PR TITLE
fix: remove unused parameter in ina219_calibrate()

### DIFF
--- a/components/ina219/ina219.c
+++ b/components/ina219/ina219.c
@@ -220,7 +220,7 @@ esp_err_t ina219_get_mode(ina219_t *dev, ina219_mode_t *mode)
     return read_conf_bits(dev, MASK_MODE, BIT_MODE, (uint16_t *)mode);
 }
 
-esp_err_t ina219_calibrate(ina219_t *dev, float i_expected_max, float r_shunt)
+esp_err_t ina219_calibrate(ina219_t *dev, float r_shunt)
 {
     CHECK_ARG(dev);
 
@@ -237,7 +237,7 @@ esp_err_t ina219_calibrate(ina219_t *dev, float i_expected_max, float r_shunt)
 
     uint16_t cal = (uint16_t)((0.04096) / (dev->i_lsb * r_shunt));
 
-    ESP_LOGD(TAG, "Calibration: %.04f A, %.04f Ohm, 0x%04x", i_expected_max, r_shunt, cal);
+    ESP_LOGD(TAG, "Calibration: %.04f Ohm, 0x%04x", r_shunt, cal);
 
     return write_reg_16(dev, REG_CALIBRATION, cal);
 }

--- a/components/ina219/ina219.h
+++ b/components/ina219/ina219.h
@@ -232,11 +232,10 @@ esp_err_t ina219_get_mode(ina219_t *dev, ina219_mode_t *mode);
  * Current readings will be valid only after calibration
  *
  * @param dev Device descriptor
- * @param i_expected_max Maximum expected current, A
  * @param r_shunt Shunt resistance, Ohm
  * @return `ESP_OK` on success
  */
-esp_err_t ina219_calibrate(ina219_t *dev, float i_expected_max, float r_shunt);
+esp_err_t ina219_calibrate(ina219_t *dev, float r_shunt);
 
 /**
  * @brief Trigger single conversion

--- a/examples/ina219/default/main/Kconfig.projbuild
+++ b/examples/ina219/default/main/Kconfig.projbuild
@@ -1,10 +1,4 @@
 menu "Example configuration"
-    config EXAMPLE_MAX_CURRENT
-        int "Expected max current in Ampare to measure"
-        default 5
-        help
-            Expected max current in Ampare. Note that the value must be int, not float.
-
     config EXAMPLE_SHUNT_RESISTOR_MILLI_OHM
         int "Shunt resistor value in milliohm)"
         default 100

--- a/examples/ina219/default/main/main.c
+++ b/examples/ina219/default/main/main.c
@@ -27,7 +27,7 @@ void task(void *pvParameters)
 
     ESP_LOGI(TAG, "Calibrating INA219");
 
-    ESP_ERROR_CHECK(ina219_calibrate(&dev, (float)CONFIG_EXAMPLE_MAX_CURRENT, (float)CONFIG_EXAMPLE_SHUNT_RESISTOR_MILLI_OHM / 1000.0f));
+    ESP_ERROR_CHECK(ina219_calibrate(&dev, (float)CONFIG_EXAMPLE_SHUNT_RESISTOR_MILLI_OHM / 1000.0f));
 
     float bus_voltage, shunt_voltage, current, power;
 


### PR DESCRIPTION
Fixes #589