### PR TITLE
Added i2c_dev_write_read_nonstop

### DIFF
--- a/components/i2cdev/i2cdev.c
+++ b/components/i2cdev/i2cdev.c
@@ -350,7 +350,7 @@ esp_err_t i2c_dev_write_read_nonstop(const i2c_dev_t *dev,
     i2c_cmd_handle_t cmd = i2c_cmd_link_create();
     i2c_master_start(cmd);
     i2c_master_write_byte(cmd, dev->addr << 1 | I2C_MASTER_WRITE, true);
-    i2c_master_write(cmd, (void *)wbuff, wsize, true);
+    i2c_master_write(cmd, wbuff, wsize, true);
     i2c_master_start(cmd);
     i2c_master_write_byte(cmd, dev->addr << 1 | I2C_MASTER_READ, true);
     i2c_master_read(cmd, rbuff, rsize, I2C_MASTER_LAST_NACK);

--- a/components/i2cdev/i2cdev.c
+++ b/components/i2cdev/i2cdev.c
@@ -338,3 +338,17 @@ esp_err_t i2c_dev_write_reg(const i2c_dev_t *dev, uint8_t reg, const void *out_d
 {
     return i2c_dev_write(dev, &reg, 1, out_data, out_size);
 }
+
+
+esp_err_t i2c_dev_write_read_nonstop(const i2c_dev_t *dev,
+        const void* wbuff, size_t wsize, void* rbuff, size_t rsize) {
+    if (!dev || !wbuff || !rbuff) return ESP_ERR_INVALID_ARG;
+
+    SEMAPHORE_TAKE(dev->port);
+    esp_err_t res;
+
+    res = i2c_master_write_read_device(dev->port, dev->addr, wbuff, wsize, rbuff, rsize, pdMS_TO_TICKS(CONFIG_I2CDEV_TIMEOUT));
+
+    SEMAPHORE_GIVE(dev->port);
+    return res;
+}

--- a/components/i2cdev/i2cdev.h
+++ b/components/i2cdev/i2cdev.h
@@ -215,6 +215,10 @@ esp_err_t i2c_dev_read_reg(const i2c_dev_t *dev, uint8_t reg,
 esp_err_t i2c_dev_write_reg(const i2c_dev_t *dev, uint8_t reg,
         const void *out_data, size_t out_size);
 
+esp_err_t i2c_dev_write_read_nonstop(const i2c_dev_t *dev,
+        const void* wbuff, size_t wsize, void* rbuff, size_t rsize);
+
+
 #define I2C_DEV_TAKE_MUTEX(dev) do { \
         esp_err_t __ = i2c_dev_take_mutex(dev); \
         if (__ != ESP_OK) return __;\

--- a/components/i2cdev/i2cdev.h
+++ b/components/i2cdev/i2cdev.h
@@ -215,6 +215,19 @@ esp_err_t i2c_dev_read_reg(const i2c_dev_t *dev, uint8_t reg,
 esp_err_t i2c_dev_write_reg(const i2c_dev_t *dev, uint8_t reg,
         const void *out_data, size_t out_size);
 
+
+/**
+ * @brief Perform a write followed by a read to a device on the I2C bus
+ *
+ * Wrapper of i2c_master_write_read_device().
+ *
+ * @param dev Device descriptor
+ * @param wbuff Write buffer (const)
+ * @param wsize Write buffer size
+ * @param rbuff Read buffer (modifiable)
+ * @param rsize Read buffer size
+ * @return ESP_OK on success
+ */
 esp_err_t i2c_dev_write_read_nonstop(const i2c_dev_t *dev,
         const void* wbuff, size_t wsize, void* rbuff, size_t rsize);
 


### PR DESCRIPTION
A wrapper of `i2c_master_write_read_device` - needed for Arduino Wire replacement (will do in the following PR).