### PR TITLE
Allow using software controlled Chip Select (CS) for MCP23S17.

### DIFF
--- a/components/mcp23x17/mcp23x17.c
+++ b/components/mcp23x17/mcp23x17.c
@@ -152,9 +152,11 @@ static esp_err_t write_reg_bit_8(mcp23x17_t *dev, uint8_t reg, bool val, uint8_t
 static esp_err_t spi_transmit(mcp23x17_t *dev, spi_transaction_t *t)
 {
     esp_err_t err;
-    if (dev->use_software_cs) gpio_set_level(dev->cs_pin, /*level=*/0);
+    if (dev->use_software_cs)
+        gpio_set_level(dev->cs_pin, 0);
     err = spi_device_transmit(dev->spi_dev, t);
-    if (dev->use_software_cs) gpio_set_level(dev->cs_pin, /*level=*/1);
+    if (dev->use_software_cs)
+        gpio_set_level(dev->cs_pin, 1);
     return err;
 }
 
@@ -322,12 +324,15 @@ esp_err_t mcp23x17_init_desc_spi(mcp23x17_t *dev, spi_host_device_t host, uint32
     dev->cs_pin = cs_pin;
 
     memset(&dev->spi_cfg, 0, sizeof(dev->spi_cfg));
-    if (dev->use_software_cs) {
+    if (dev->use_software_cs)
+    {
         // Configure software Chip Select (CS) and pull the pin high.
         dev->spi_cfg.spics_io_num = -1;
         CHECK(gpio_set_direction(dev->cs_pin, GPIO_MODE_OUTPUT));
-        CHECK(gpio_set_level(dev->cs_pin, /*level=*/1));
-    } else {
+        CHECK(gpio_set_level(dev->cs_pin, 1));
+    }
+    else
+    {
         // Configure hardware CS.
         dev->spi_cfg.spics_io_num = dev->cs_pin;
     }

--- a/components/mcp23x17/mcp23x17.h
+++ b/components/mcp23x17/mcp23x17.h
@@ -65,11 +65,10 @@ typedef struct
     spi_device_interface_config_t spi_cfg;
     spi_device_handle_t spi_dev;
     uint8_t addr;
-    // Whether to use a software Chip Select (CS) line instead of the hardware
-    // one. This is useful when multiple MCP23S17 chips are sharing the same CS
-    // line on the SPI bus.
     bool use_software_cs; //!< Use software CS control instead of hardware.
-    // CS GPIO pin number, populated by the `mcp23x17_init_desc_spi` function.
+                          //!< Whether to use a software Chip Select (CS) line instead of the hardware
+                          //!< one. This is useful when multiple MCP23S17 chips are sharing the same CS
+                          //!< line on the SPI bus.
     gpio_port_t cs_pin;   //!< GPIO pin number for CS.
 } mcp23x17_t;
 

--- a/components/mcp23x17/mcp23x17.h
+++ b/components/mcp23x17/mcp23x17.h
@@ -65,6 +65,12 @@ typedef struct
     spi_device_interface_config_t spi_cfg;
     spi_device_handle_t spi_dev;
     uint8_t addr;
+    // Whether to use a software Chip Select (CS) line instead of the hardware
+    // one. This is useful when multiple MCP23S17 chips are sharing the same CS
+    // line on the SPI bus.
+    bool use_software_cs; //!< Use software CS control instead of hardware.
+    // CS GPIO pin number, populated by the `mcp23x17_init_desc_spi` function.
+    gpio_port_t cs_pin;   //!< GPIO pin number for CS.
 } mcp23x17_t;
 
 #endif


### PR DESCRIPTION
  * This is useful when multiple devices, with a different addresses, are sharing the same CS line on the SPI bus.