### PR TITLE
Update README.md : Fixed exclude components for ESP8266

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ e.g:
 ```Makefile
 PROJECT_NAME := my-esp-project
 EXTRA_COMPONENT_DIRS := /home/user/myprojects/esp/esp-idf-lib/components
-EXCLUDE_COMPONENTS := max7219 mcp23x17 led_strip max31865 ls7366r max31855
+EXCLUDE_COMPONENTS := ads130e08 max7219 mcp23x17 led_strip max31865 ls7366r max31855
 include $(IDF_PATH)/make/project.mk
 ```
 


### PR DESCRIPTION
Added ads130e08 to the excluded components for the ESP8266 RTOS SDK Makefile