### PR TITLE
Add ESP32-H2 support for I2C in sdkconfig defaults

### DIFF
--- a/examples/ads111x/default/main/Kconfig.projbuild
+++ b/examples/ads111x/default/main/Kconfig.projbuild
@@ -10,6 +10,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -18,6 +19,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/aht/default/main/Kconfig.projbuild
+++ b/examples/aht/default/main/Kconfig.projbuild
@@ -32,6 +32,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -40,6 +41,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/am2320/default/main/Kconfig.projbuild
+++ b/examples/am2320/default/main/Kconfig.projbuild
@@ -5,6 +5,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -13,6 +14,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 

--- a/examples/bh1750/default/main/Kconfig.projbuild
+++ b/examples/bh1750/default/main/Kconfig.projbuild
@@ -20,6 +20,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -28,6 +29,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/bh1900nux/default/main/Kconfig.projbuild
+++ b/examples/bh1900nux/default/main/Kconfig.projbuild
@@ -21,6 +21,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -29,6 +30,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/bme680/default/main/Kconfig.projbuild
+++ b/examples/bme680/default/main/Kconfig.projbuild
@@ -16,6 +16,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -24,6 +25,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/bmp280/default/main/Kconfig.projbuild
+++ b/examples/bmp280/default/main/Kconfig.projbuild
@@ -4,6 +4,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -12,6 +13,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/dps310/altitude/main/Kconfig.projbuild
+++ b/examples/dps310/altitude/main/Kconfig.projbuild
@@ -4,6 +4,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -12,6 +13,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
     config EXAMPLE_I2C_ADDRESS

--- a/examples/dps310/default/main/Kconfig.projbuild
+++ b/examples/dps310/default/main/Kconfig.projbuild
@@ -4,6 +4,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -12,6 +13,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
     config EXAMPLE_I2C_ADDRESS

--- a/examples/ds3502/default/main/Kconfig.projbuild
+++ b/examples/ds3502/default/main/Kconfig.projbuild
@@ -20,6 +20,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -28,6 +29,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/hd44780/i2c/main/Kconfig.projbuild
+++ b/examples/hd44780/i2c/main/Kconfig.projbuild
@@ -8,6 +8,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -16,6 +17,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/hd44780/simplest_barometer/main/Kconfig.projbuild
+++ b/examples/hd44780/simplest_barometer/main/Kconfig.projbuild
@@ -10,6 +10,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -18,6 +19,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/hdc1000/default/main/Kconfig.projbuild
+++ b/examples/hdc1000/default/main/Kconfig.projbuild
@@ -12,6 +12,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -20,6 +21,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/ht16k33/default/main/Kconfig.projbuild
+++ b/examples/ht16k33/default/main/Kconfig.projbuild
@@ -10,6 +10,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -18,6 +19,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/i2cdev/default/main/Kconfig.projbuild
+++ b/examples/i2cdev/default/main/Kconfig.projbuild
@@ -5,6 +5,7 @@ menu "I2C scanner configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -13,6 +14,7 @@ menu "I2C scanner configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 

--- a/examples/icm42670/default/main/Kconfig.projbuild
+++ b/examples/icm42670/default/main/Kconfig.projbuild
@@ -16,6 +16,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -24,6 +25,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 

--- a/examples/ina219/default/main/Kconfig.projbuild
+++ b/examples/ina219/default/main/Kconfig.projbuild
@@ -18,6 +18,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -26,6 +27,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/ina3221/default/main/Kconfig.projbuild
+++ b/examples/ina3221/default/main/Kconfig.projbuild
@@ -28,6 +28,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -36,6 +37,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/lc709203f/default/main/Kconfig.projbuild
+++ b/examples/lc709203f/default/main/Kconfig.projbuild
@@ -4,6 +4,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -12,6 +13,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
     

--- a/examples/lm75/default/main/Kconfig.projbuild
+++ b/examples/lm75/default/main/Kconfig.projbuild
@@ -4,6 +4,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -12,6 +13,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/max31725/default/main/Kconfig.projbuild
+++ b/examples/max31725/default/main/Kconfig.projbuild
@@ -21,6 +21,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -29,6 +30,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/mcp23x17/mcp23017/main/Kconfig.projbuild
+++ b/examples/mcp23x17/mcp23017/main/Kconfig.projbuild
@@ -19,6 +19,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -27,6 +28,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/mcp4725/default/main/Kconfig.projbuild
+++ b/examples/mcp4725/default/main/Kconfig.projbuild
@@ -13,6 +13,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -21,6 +22,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/mcp9808/default/main/Kconfig.projbuild
+++ b/examples/mcp9808/default/main/Kconfig.projbuild
@@ -12,6 +12,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -20,6 +21,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/mp2660/default/main/Kconfig.projbuild
+++ b/examples/mp2660/default/main/Kconfig.projbuild
@@ -4,6 +4,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 22 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -12,6 +13,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 21 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/mpu6050/default/main/Kconfig.projbuild
+++ b/examples/mpu6050/default/main/Kconfig.projbuild
@@ -21,6 +21,7 @@ menu "MPU6050 Example Configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -29,6 +30,7 @@ menu "MPU6050 Example Configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
      

--- a/examples/ms5611/default/main/Kconfig.projbuild
+++ b/examples/ms5611/default/main/Kconfig.projbuild
@@ -20,6 +20,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -28,6 +29,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/pca9557/default/main/Kconfig.projbuild
+++ b/examples/pca9557/default/main/Kconfig.projbuild
@@ -19,6 +19,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -27,6 +28,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/pca9685/default/main/Kconfig.projbuild
+++ b/examples/pca9685/default/main/Kconfig.projbuild
@@ -12,6 +12,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -20,6 +21,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/qmp6988/default/main/Kconfig.projbuild
+++ b/examples/qmp6988/default/main/Kconfig.projbuild
@@ -30,6 +30,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -38,6 +39,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/scd30/default/main/Kconfig.projbuild
+++ b/examples/scd30/default/main/Kconfig.projbuild
@@ -4,6 +4,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -12,6 +13,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/sgm58031/default/main/Kconfig.projbuild
+++ b/examples/sgm58031/default/main/Kconfig.projbuild
@@ -10,6 +10,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -18,6 +19,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/sgp40/default/main/Kconfig.projbuild
+++ b/examples/sgp40/default/main/Kconfig.projbuild
@@ -12,6 +12,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -20,6 +21,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/sht3x/default/main/Kconfig.projbuild
+++ b/examples/sht3x/default/main/Kconfig.projbuild
@@ -33,6 +33,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -41,6 +42,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/si7021/default/main/Kconfig.projbuild
+++ b/examples/si7021/default/main/Kconfig.projbuild
@@ -20,6 +20,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -28,6 +29,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/sts21/default/main/Kconfig.projbuild
+++ b/examples/sts21/default/main/Kconfig.projbuild
@@ -5,6 +5,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -13,6 +14,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/tca6424a/default/main/Kconfig.projbuild
+++ b/examples/tca6424a/default/main/Kconfig.projbuild
@@ -27,6 +27,7 @@ menu "Example configuration"
         int "SCL GPIO Number"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
+        default 4 if IDF_TARGET_ESP32H2
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
         help
             GPIO number for I2C Master clock line.
@@ -35,6 +36,7 @@ menu "Example configuration"
         int "SDA GPIO Number"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
+        default 3 if IDF_TARGET_ESP32H2
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
         help
             GPIO number for I2C Master data line.

--- a/examples/tca9548/default/main/Kconfig.projbuild
+++ b/examples/tca9548/default/main/Kconfig.projbuild
@@ -8,6 +8,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -16,6 +17,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/tca95x5/default/main/Kconfig.projbuild
+++ b/examples/tca95x5/default/main/Kconfig.projbuild
@@ -12,6 +12,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -20,6 +21,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 

--- a/examples/tda74xx/default/main/Kconfig.projbuild
+++ b/examples/tda74xx/default/main/Kconfig.projbuild
@@ -50,6 +50,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -58,6 +59,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/tsl2591/default/main/Kconfig.projbuild
+++ b/examples/tsl2591/default/main/Kconfig.projbuild
@@ -5,6 +5,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -13,6 +14,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 

--- a/examples/tsys01/default/main/Kconfig.projbuild
+++ b/examples/tsys01/default/main/Kconfig.projbuild
@@ -15,6 +15,7 @@ menu "Example configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -23,6 +24,7 @@ menu "Example configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 endmenu

--- a/examples/veml7700/default/main/Kconfig.projbuild
+++ b/examples/veml7700/default/main/Kconfig.projbuild
@@ -5,6 +5,7 @@ menu "Example Configuration"
         default 5 if IDF_TARGET_ESP8266
         default 6 if IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32C2 || IDF_TARGET_ESP32H2
         default 19 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 4 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master clock line.
 
@@ -13,6 +14,7 @@ menu "Example Configuration"
         default 4 if IDF_TARGET_ESP8266
         default 5 if IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32C2 || IDF_TARGET_ESP32H2
         default 18 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+        default 3 if IDF_TARGET_ESP32H2
         help
             GPIO number for I2C Master data line.
 


### PR DESCRIPTION
Added I2C GPIO pins for I2C for ESP32-H2 in Kconfig.projbuild, hopefully, all examples