### PR TITLE
ds3502 set function check for max value has wrong comparison

### DIFF
--- a/components/ds3502/ds3502.c
+++ b/components/ds3502/ds3502.c
@@ -96,7 +96,7 @@ esp_err_t ds3502_get(i2c_dev_t *dev, uint8_t *pos)
 
 esp_err_t ds3502_set(i2c_dev_t *dev, uint8_t pos, bool save)
 {
-    CHECK_ARG(dev && pos >= DS3502_MAX);
+    CHECK_ARG(dev && pos <= DS3502_MAX);
 
     I2C_DEV_TAKE_MUTEX(dev);
     if (save)


### PR DESCRIPTION
should be less than max value, not greater than.  In its current state it rejects all valid messages.