### PR TITLE
Amend: Use BIT64() instead of BIT() to accommodate PINS >= 32

### DIFF
--- a/components/hx711/hx711.c
+++ b/components/hx711/hx711.c
@@ -92,15 +92,15 @@ esp_err_t hx711_init(hx711_t *dev)
     CHECK_ARG(dev);
 
     gpio_config_t conf = {
-        .pin_bit_mask = BIT(dev->dout),
+        .pin_bit_mask = BIT64(dev->dout),
         .mode = GPIO_MODE_INPUT,
         .pull_up_en = 0,
         .pull_down_en = 0,
-        .intr_type = GPIO_INTR_DISABLE
+        .intr_type = GPIO_INTR_DISABLE,
     };
     CHECK(gpio_config(&conf));
 
-    conf.pin_bit_mask = BIT(dev->pd_sck);
+    conf.pin_bit_mask = BIT64(dev->pd_sck);
     conf.mode = GPIO_MODE_OUTPUT;
     CHECK(gpio_config(&conf));
 


### PR DESCRIPTION
Utilizing BIT64() instead of BIT() in hx711 component as BIT is only for 32 bit, hence using any PINs above 31 becomes a problem.