### PR TITLE
fix: add missing `const` to `_write_reg`

### DIFF
--- a/components/dps310/priv_include/helper_i2c.h
+++ b/components/dps310/priv_include/helper_i2c.h
@@ -58,7 +58,7 @@ esp_err_t _read_reg_mask(i2c_dev_t *dev, uint8_t reg, uint8_t mask, uint8_t *val
 /**
  * @brief Write a single byte to a 8-bit resister with locking.
  */
-esp_err_t _write_reg(i2c_dev_t *dev, uint8_t reg, uint8_t *value);
+esp_err_t _write_reg(i2c_dev_t *dev, uint8_t reg, const uint8_t *value);
 
 /**
  * @brief Update a 8-bit resister with a masked value without locking.

--- a/components/dps310/src/helper_i2c.c
+++ b/components/dps310/src/helper_i2c.c
@@ -120,7 +120,7 @@ esp_err_t _update_reg_nolock(i2c_dev_t *dev, uint8_t reg, uint8_t mask, uint8_t 
     return ESP_OK;
 }
 
-esp_err_t _write_reg(i2c_dev_t *dev, uint8_t reg, uint8_t *value)
+esp_err_t _write_reg(i2c_dev_t *dev, uint8_t reg, const uint8_t *value)
 {
     esp_err_t err = ESP_FAIL;
 


### PR DESCRIPTION
The `value` in `_write_reg` could be a _pointer to const_. This PR fixes that.