### PR TITLE
mark max1704x TAG const

### DIFF
--- a/components/example/example.c
+++ b/components/example/example.c
@@ -33,7 +33,7 @@
 
 /* do NOT use upper case for variables. use `snake_case` instead of
  * `CamelCase`. */
-static char *tag = "example";
+static const char *tag = "example";
 
 /* prefix public function names with the component name, `example_` in this
  * case. */

--- a/components/max1704x/max1704x.c
+++ b/components/max1704x/max1704x.c
@@ -98,7 +98,7 @@
 #define CHECK(x) do { esp_err_t __; if ((__ = x) != ESP_OK) return __; } while (0)
 #define CHECK_ARG(ARG) do { if (!(ARG)) return ESP_ERR_INVALID_ARG; } while (0)
 
-static char *TAG = "max1704x";
+static const char *TAG = "max1704x";
 
 /**
  * Private functions


### PR DESCRIPTION
This allows us to use `-wwrite-strings` over the repo. Otherwise we get:

```c
/home/dank/esp/build/_deps/espidflib-src/components/max1704x/max1704x.c:101:20: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  101 | static char *TAG = "max1704x";
      |                    ^~~~~~~~~~
```