### PR TITLE
Update dht.c

### DIFF
--- a/components/dht/dht.c
+++ b/components/dht/dht.c
@@ -120,7 +120,7 @@ static esp_err_t dht_await_pin_state(gpio_num_t pin, uint32_t timeout,
     for (uint32_t i = 0; i < timeout; i += DHT_TIMER_INTERVAL)
     {
         // need to wait at least a single interval to prevent reading a jitter
-        ets_delay_us(DHT_TIMER_INTERVAL);
+        esp_rom_delay_us(DHT_TIMER_INTERVAL);
         if (gpio_get_level(pin) == expected_pin_state)
         {
             if (duration)
@@ -145,7 +145,7 @@ static inline esp_err_t dht_fetch_data(dht_sensor_type_t sensor_type, gpio_num_t
     // Phase 'A' pulling signal low to initiate read sequence
     gpio_set_direction(pin, GPIO_MODE_OUTPUT_OD);
     gpio_set_level(pin, 0);
-    ets_delay_us(sensor_type == DHT_TYPE_SI7021 ? 500 : 20000);
+    esp_rom_delay_us(sensor_type == DHT_TYPE_SI7021 ? 500 : 20000);
     gpio_set_level(pin, 1);
 
     // Step through Phase 'B', 40us


### PR DESCRIPTION
Fixed broken function call. `ets_delay_us()` doesn't exist anymore: an equivalent function is now titled `esp_rom_delay_us()`.