### PR TITLE
scd4x: fix wake_up function

### DIFF
--- a/components/i2cdev/i2cdev.h
+++ b/components/i2cdev/i2cdev.h
@@ -188,6 +188,23 @@ esp_err_t i2c_dev_write(const i2c_dev_t *dev, const void *out_reg,
         size_t out_reg_size, const void *out_data, size_t out_size);
 
 /**
+ * @brief Write to a slave device without waiting for ACK
+ *
+ * Write \p out_size bytes from \p out_data to slave into \p out_reg register address.
+ * The master will not wait for an ACK signal from the slave device after sending data.
+ * Function is thread-safe.
+ *
+ * @param dev Device descriptor
+ * @param out_reg Pointer to register address to send if non-null
+ * @param out_reg_size Size of register address
+ * @param out_data Pointer to data to send
+ * @param out_size Size of data to send
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_write_no_ack(const i2c_dev_t *dev, const void *out_reg,
+        size_t out_reg_size, const void *out_data, size_t out_size);
+
+/**
  * @brief Read from register with an 8-bit address
  *
  * Shortcut to ::i2c_dev_read().


### PR DESCRIPTION
Added `i2c_dev_write_no_ack` to perform writes without waiting for ACK and updated `scd4x_wake_up` accordingly. Increased delay time in `scd4x_wake_up` from 20 to 30 based on the datasheet.

I could not find an I2C function that sends a command without waiting for ACK, which is what I needed. That is why I created a new function in `i2cdev`. I am open to other ideas if you don't like this solution.

Fixes #582