### PR TITLE
fix: ultrasonic temperature compensated measuring

### DIFF
--- a/components/ultrasonic/ultrasonic.c
+++ b/components/ultrasonic/ultrasonic.c
@@ -48,7 +48,7 @@
 #define PING_TIMEOUT 6000
 #define ROUNDTRIP_M 5800.0f
 #define ROUNDTRIP_CM 58
-#define SPEED_OF_SOUND_AT_0C_M_S 331.4 // Speed of sound in m/s at 0 degrees Celsius
+#define HALF_SPEED_OF_SOUND_AT_0C_M_S 165.7 // Half speed of sound in m/s at 0 degrees Celsius
 
 #if HELPER_TARGET_IS_ESP32
 static portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
@@ -147,8 +147,8 @@ esp_err_t ultrasonic_measure_temp_compensated(const ultrasonic_sensor_t *dev, fl
 {
     CHECK_ARG(dev && distance);
 
-    // Calculate the speed of sound in m/us based on temperature
-    float speed_of_sound = (SPEED_OF_SOUND_AT_0C_M_S + 0.6 * temperature_c) / 1000000; // Convert m/s to m/us
+    // Calculate half (because of roundtrip) speed of sound in m/us based on temperature
+    float speed_of_sound = (HALF_SPEED_OF_SOUND_AT_0C_M_S + 0.6 * temperature_c) / 1000000; // Convert m/s to m/us
 
     uint32_t time_us;
     // Adjust max_time_us based on the recalculated speed of sound
@@ -163,8 +163,8 @@ esp_err_t ultrasonic_measure_cm_temp_compensated(const ultrasonic_sensor_t *dev,
 {
     CHECK_ARG(dev && distance);
 
-    // Calculate the speed of sound in cm/us based on temperature
-    float speed_of_sound_cm_us = ((SPEED_OF_SOUND_AT_0C_M_S + 0.6 * temperature_c) * 100) / 1000000; // Convert m/s to cm/us
+    // Calculate half (because of roundtrip) speed of sound in cm/us based on temperature
+    float speed_of_sound_cm_us = ((HALF_SPEED_OF_SOUND_AT_0C_M_S + 0.6 * temperature_c) * 100) / 1000000; // Convert m/s to cm/us
 
     uint32_t time_us;
     // Adjust max_time_us based on the recalculated speed of sound in cm


### PR DESCRIPTION
Use half speed of sound for calculating distance in temperature compensated measuring functions (because of the roundtrip of the sound).

Fixes: #699